### PR TITLE
Pipeline builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added `PipelineBuilder`, a more ergonomic way to configure OpenTelemetry with the Application Insights span exporter.
+
 ## [0.4.0] - 2020-08-14
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,14 @@ exclude = [
 ]
 
 [dependencies]
+# async_std::stream::interval requires the "unstable" feature
+async-std = { version = "1.6", features = ["unstable"], optional = true }
 chrono = "0.4"
 log = "0.4"
 opentelemetry = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "0.2", features = ["rt-core", "time", "stream"], optional = true }
 ureq = { version = "1.3", features = ["json"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -16,15 +16,12 @@ An [Azure Application Insights] exporter implementation for [OpenTelemetry Rust]
 Configure the exporter:
 
 ```rust
-use opentelemetry::{global, sdk};
+use opentelemetry::sdk;
 
-fn init_tracer() {
+fn init_tracer() -> sdk::Tracer {
     let instrumentation_key = "...".to_string();
-    let exporter = opentelemetry_application_insights::Exporter::new(instrumentation_key);
-    let provider = sdk::Provider::builder()
-        .with_simple_exporter(exporter)
-        .build();
-    global::set_provider(provider);
+    opentelemetry_application_insights::new_pipeline(instrumentation_key)
+        .install()
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,21 +13,27 @@ An [Azure Application Insights] exporter implementation for [OpenTelemetry Rust]
 
 ## Usage
 
-Configure the exporter:
+Configure a OpenTelemetry pipeline using the Application Insights exporter and start creating
+spans:
 
 ```rust
-use opentelemetry::sdk;
+use opentelemetry::{api::Tracer, sdk};
 
 fn init_tracer() -> sdk::Tracer {
     let instrumentation_key = "...".to_string();
     opentelemetry_application_insights::new_pipeline(instrumentation_key)
         .install()
 }
+
+fn main() {
+    let tracer = init_tracer();
+    tracer.in_span("main", |_cx| {});
+}
 ```
 
-Then follow the documentation of [opentelemetry] to create spans and events.
-
-[opentelemetry]: https://github.com/open-telemetry/opentelemetry-rust
+The functions `build` and `install` automatically configure an asynchronous batch exporter if
+you use this crate with either the `async-std` or `tokio` feature. Otherwise spans will be
+exported synchronously.
 
 ## Attribute mapping
 

--- a/examples/attributes.rs
+++ b/examples/attributes.rs
@@ -20,24 +20,20 @@ fn main() {
     let instrumentation_key =
         env::var("INSTRUMENTATION_KEY").expect("env var INSTRUMENTATION_KEY should exist");
 
-    let client_exporter =
-        opentelemetry_application_insights::Exporter::new(instrumentation_key.clone());
-    let client_provider = sdk::Provider::builder()
-        .with_simple_exporter(client_exporter)
-        .with_config(sdk::Config {
-            resource: Arc::new(sdk::Resource::new(vec![
-                KeyValue::new("service.namespace", "example-attributes"),
-                KeyValue::new("service.name", "client"),
-            ])),
-            ..sdk::Config::default()
-        })
-        .build();
+    let client_provider =
+        opentelemetry_application_insights::new_pipeline(instrumentation_key.clone())
+            .with_sdk_config(sdk::Config {
+                resource: Arc::new(sdk::Resource::new(vec![
+                    KeyValue::new("service.namespace", "example-attributes"),
+                    KeyValue::new("service.name", "client"),
+                ])),
+                ..sdk::Config::default()
+            })
+            .build();
     let client_tracer = client_provider.get_tracer("example-attributes");
 
-    let server_exporter = opentelemetry_application_insights::Exporter::new(instrumentation_key);
-    let server_provider = sdk::Provider::builder()
-        .with_simple_exporter(server_exporter)
-        .with_config(sdk::Config {
+    let server_provider = opentelemetry_application_insights::new_pipeline(instrumentation_key)
+        .with_sdk_config(sdk::Config {
             resource: Arc::new(sdk::Resource::new(vec![
                 KeyValue::new("service.namespace", "example-attributes"),
                 KeyValue::new("service.name", "server"),

--- a/examples/opentelemetry.rs
+++ b/examples/opentelemetry.rs
@@ -3,7 +3,7 @@ use opentelemetry::{
         trace::futures::FutureExt, Context, HttpTextFormat, Key, Span, SpanKind, TraceContextExt,
         TraceContextPropagator, Tracer,
     },
-    global, sdk,
+    global,
 };
 use std::collections::HashMap;
 use std::env;
@@ -68,11 +68,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let instrumentation_key =
         env::var("INSTRUMENTATION_KEY").expect("env var INSTRUMENTATION_KEY should exist");
-    let exporter = opentelemetry_application_insights::Exporter::new(instrumentation_key);
-    let provider = sdk::Provider::builder()
-        .with_simple_exporter(exporter)
-        .build();
-    global::set_provider(provider);
+    opentelemetry_application_insights::new_pipeline(instrumentation_key).install();
 
     match traceparent {
         Some(traceparent) => {

--- a/examples/tracing.rs
+++ b/examples/tracing.rs
@@ -1,7 +1,4 @@
-use opentelemetry::{
-    api::{HttpTextFormat, Provider, TraceContextPropagator},
-    sdk,
-};
+use opentelemetry::api::{HttpTextFormat, TraceContextPropagator};
 use std::collections::HashMap;
 use std::env;
 use std::error::Error;
@@ -53,12 +50,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let instrumentation_key =
         env::var("INSTRUMENTATION_KEY").expect("env var INSTRUMENTATION_KEY should exist");
-    let exporter = opentelemetry_application_insights::Exporter::new(instrumentation_key);
-    let provider = sdk::Provider::builder()
-        .with_simple_exporter(exporter)
-        .build();
-
-    let tracer = provider.get_tracer("example-tracing");
+    let tracer = opentelemetry_application_insights::new_pipeline(instrumentation_key).install();
     let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
     let subscriber = Registry::default().with(telemetry);
     tracing::subscriber::set_global_default(subscriber).expect("setting global default failed");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,15 +10,12 @@
 //! Configure the exporter:
 //!
 //! ```rust,no_run
-//! use opentelemetry::{global, sdk};
+//! use opentelemetry::sdk;
 //!
-//! fn init_tracer() {
+//! fn init_tracer() -> sdk::Tracer {
 //!     let instrumentation_key = "...".to_string();
-//!     let exporter = opentelemetry_application_insights::Exporter::new(instrumentation_key);
-//!     let provider = sdk::Provider::builder()
-//!         .with_simple_exporter(exporter)
-//!         .build();
-//!     global::set_provider(provider);
+//!     opentelemetry_application_insights::new_pipeline(instrumentation_key)
+//!         .install()
 //! }
 //! ```
 //!
@@ -95,12 +92,127 @@ use convert::{
     attrs_to_properties, collect_attrs, duration_to_string, span_id_to_string, time_to_string,
 };
 use models::{Data, Envelope, MessageData, RemoteDependencyData, RequestData, Sanitize};
-use opentelemetry::api::{Event, SpanKind, StatusCode};
+use opentelemetry::api::{Event, Provider, SpanKind, StatusCode};
 use opentelemetry::exporter::trace;
+use opentelemetry::global;
+use opentelemetry::sdk;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tags::{get_tags_for_event, get_tags_for_span};
+
+/// Create a new Application Insights exporter pipeline builder
+pub fn new_pipeline(instrumentation_key: String) -> PipelineBuilder {
+    PipelineBuilder {
+        instrumentation_key,
+        sample_rate: 100.0,
+        config: None,
+    }
+}
+
+/// Application Insights exporter builder
+#[derive(Debug)]
+pub struct PipelineBuilder {
+    instrumentation_key: String,
+    sample_rate: f64,
+    config: Option<sdk::Config>,
+}
+
+impl PipelineBuilder {
+    /// Set sample rate, which is passed through to Application Insights. It should be a value
+    /// between 0 and 1 and match the rate given to the sampler.
+    ///
+    /// Default: 1.0
+    ///
+    /// ```
+    /// let sample_rate = 0.3;
+    /// let tracer = opentelemetry_application_insights::new_pipeline("...".into())
+    ///     .with_sample_rate(sample_rate)
+    ///     .install();
+    /// ```
+    pub fn with_sample_rate(mut self, sample_rate: f64) -> Self {
+        // Application Insights expects the sample rate as a percentage.
+        self.sample_rate = sample_rate * 100.0;
+        self
+    }
+
+    /// Assign the SDK config for the exporter pipeline.
+    ///
+    /// ```
+    /// # use opentelemetry::{api::KeyValue, sdk};
+    /// # use std::sync::Arc;
+    /// let tracer = opentelemetry_application_insights::new_pipeline("...".into())
+    ///     .with_sdk_config(sdk::Config {
+    ///         resource: Arc::new(sdk::Resource::new(vec![
+    ///             KeyValue::new("service.name", "my-application"),
+    ///         ])),
+    ///         ..sdk::Config::default()
+    ///     })
+    ///     .install();
+    /// ```
+    pub fn with_sdk_config(self, config: sdk::Config) -> Self {
+        PipelineBuilder {
+            config: Some(config),
+            ..self
+        }
+    }
+
+    /// Install a Application Insights pipeline with the recommended defaults.
+    pub fn install(self) -> sdk::Tracer {
+        let trace_provider = self.build();
+        let tracer = trace_provider.get_tracer("opentelemetry-application-insights");
+
+        global::set_provider(trace_provider);
+
+        tracer
+    }
+
+    /// Build a configured `sdk::Provider` with the recommended defaults.
+    pub fn build(mut self) -> sdk::Provider {
+        let config = self.config.take();
+        let exporter = self.init_exporter();
+
+        let mut builder = sdk::Provider::builder();
+
+        #[cfg(feature = "tokio")]
+        {
+            let batch =
+                sdk::BatchSpanProcessor::builder(exporter, tokio::spawn, tokio::time::interval)
+                    .build();
+            builder = builder.with_batch_exporter(batch);
+        }
+        #[cfg(all(feature = "async-std", not(feature = "tokio")))]
+        {
+            let batch = sdk::BatchSpanProcessor::builder(
+                exporter,
+                async_std::task::spawn,
+                async_std::stream::interval,
+            )
+            .build();
+            builder = builder.with_batch_exporter(batch);
+        }
+        #[cfg(all(not(feature = "async-std"), not(feature = "tokio")))]
+        {
+            builder = builder.with_simple_exporter(exporter);
+        }
+
+        if let Some(config) = config {
+            builder = builder.with_config(config);
+        }
+
+        builder.build()
+    }
+
+    /// Initialize a new exporter.
+    ///
+    /// This is useful if you are manually constructing a pipeline.
+    pub fn init_exporter(self) -> Exporter {
+        Exporter {
+            instrumentation_key: self.instrumentation_key,
+            sample_rate: self.sample_rate,
+        }
+    }
+}
 
 /// Application Insights span exporter
 #[derive(Debug)]
@@ -110,38 +222,6 @@ pub struct Exporter {
 }
 
 impl Exporter {
-    /// Create a new exporter.
-    pub fn new(instrumentation_key: String) -> Self {
-        Self {
-            instrumentation_key,
-            sample_rate: 100.0,
-        }
-    }
-
-    /// Set sample rate, which is passed through to Application Insights. It should be a value
-    /// between 0 and 1 and match the rate given to the sampler.
-    ///
-    /// Default: 1.0
-    ///
-    /// ```
-    /// # use opentelemetry::{global, sdk};
-    /// let sample_rate = 0.3;
-    /// let exporter = opentelemetry_application_insights::Exporter::new("...".into())
-    ///     .with_sample_rate(sample_rate);
-    /// let provider = sdk::Provider::builder()
-    ///     .with_simple_exporter(exporter)
-    ///     .with_config(sdk::Config {
-    ///         default_sampler: Box::new(sdk::Sampler::Probability(sample_rate)),
-    ///         ..Default::default()
-    ///     })
-    ///     .build();
-    /// ```
-    pub fn with_sample_rate(mut self, sample_rate: f64) -> Self {
-        // Application Insights expects the sample rate as a percentage.
-        self.sample_rate = sample_rate * 100.0;
-        self
-    }
-
     fn create_envelopes(&self, span: Arc<trace::SpanData>) -> Vec<Envelope> {
         let mut result = Vec::with_capacity(1 + span.message_events.len());
 


### PR DESCRIPTION
A more ergonomic way to create a OpenTelemetry pipeline with the Application Insights span exporter.