### PR TITLE
Make endpoint configurable

### DIFF
--- a/examples/http_client_reqwest.rs
+++ b/examples/http_client_reqwest.rs
@@ -1,4 +1,4 @@
-use opentelemetry::trace::Tracer;
+use opentelemetry::trace::Tracer as _;
 use std::env;
 
 #[tokio::main]

--- a/examples/http_client_reqwest_blocking.rs
+++ b/examples/http_client_reqwest_blocking.rs
@@ -1,4 +1,4 @@
-use opentelemetry::trace::Tracer;
+use opentelemetry::trace::Tracer as _;
 use std::env;
 
 fn main() {

--- a/examples/http_client_surf.rs
+++ b/examples/http_client_surf.rs
@@ -1,4 +1,4 @@
-use opentelemetry::trace::Tracer;
+use opentelemetry::trace::Tracer as _;
 use std::env;
 
 #[async_std::main]

--- a/src/uploader.rs
+++ b/src/uploader.rs
@@ -1,10 +1,9 @@
 use crate::models::Envelope;
 use crate::HttpClient;
-use http::Request;
+use http::{Request, Uri};
 use opentelemetry::exporter::trace::ExportResult;
 use serde::Deserialize;
 
-const URL: &str = "https://dc.services.visualstudio.com/v2/track";
 const STATUS_OK: u16 = 200;
 const STATUS_PARTIAL_CONTENT: u16 = 206;
 const STATUS_REQUEST_TIMEOUT: u16 = 408;
@@ -30,9 +29,13 @@ struct TransmissionItem {
 }
 
 /// Sends a telemetry items to the server.
-pub(crate) async fn send(client: &dyn HttpClient, items: Vec<Envelope>) -> ExportResult {
+pub(crate) async fn send(
+    client: &dyn HttpClient,
+    endpoint: &Uri,
+    items: Vec<Envelope>,
+) -> ExportResult {
     let payload = serde_json::to_vec(&items)?;
-    let request = Request::post(URL)
+    let request = Request::post(endpoint)
         .header(http::header::CONTENT_TYPE, "application/json")
         .body(payload)?;
 


### PR DESCRIPTION
Fixes #20 

It looks like only the origin can change. The path seems to be fixed. Based on:
- https://github.com/Azure/azure-rest-api-specs/blob/e47988f3ccaa90681f11cce59c25c638ff305692/specification/applicationinsights/data-plane/Monitor.Exporters/preview/2020-09-15_Preview/swagger.json
- https://github.com/microsoft/opentelemetry-azure-monitor-python/blob/2fc7e100653fc33cb480ffd5ff068edbe311bcec/azure_monitor/src/azure_monitor/options.py#L103