### PR TITLE
Fix #23.

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -22,7 +22,7 @@ pub(crate) fn duration_to_string(duration: Duration) -> String {
     let d = micros / 1_000_000 / 60 / 60 / 24;
     let micros_remaining = micros % 1_000_000;
     format!(
-        "{}.{:0>2}:{:0>2}:{:0>2}.{:0>7}",
+        "{}.{:0>2}:{:0>2}:{:0>2}.{:0>6}",
         d, h, m, s, micros_remaining
     )
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -64,7 +64,7 @@ mod tests {
         assert_eq!(expected.to_string(), span_id_to_string(id));
     }
 
-    #[test_case(Duration::from_micros(123456789123), "1.10:17:36.0789123" ; "all")]
+    #[test_case(Duration::from_micros(123456789123), "1.10:17:36.789123" ; "all")]
     fn duration(duration: Duration, expected: &'static str) {
         assert_eq!(expected.to_string(), duration_to_string(duration));
     }


### PR DESCRIPTION
The `duration_to_string` method has a small bug.

The padding for the microseconds was `7`; however, given the way the remaining micros are calculated, the remaining micros will only ever be a maximum of 6 digits.  In addition, microseconds in datetime strings should be formatted as exactly 6 digits.

Say you had `999999` microseconds remaining.  We would read this as `999 ms`.  However, using a padding of `7` makes this `0999999` microseconds.  I am guessing that app insights ignores the last digit, and consumes this as `099999` microseconds, or `99 ms`.

This should fix that issue.