### PR TITLE
Allow for custom attributes to map to tags.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ reqwest = { version = "0.10", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 surf = { version = "2.0", optional = true }
+once_cell = "1.5.2"
 
 [dev-dependencies]
 async-std = { version = "1.6.5", features = ["attributes"] }

--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ All other attributes are directly converted to custom properties.
 
 For Requests the attributes `http.method` and `http.route` override the Name.
 
+#### Automatic Attribute Mappings
+
+| OpenTelemetry Attribute                           | AppInsights Tag          | Notes                                                                                               |
+|---------------------------------------------------|--------------------------|-----------------------------------------------------------------------------------------------------|
+| Span Id                                           | `ai.operation.id`        |                                                                                                     |
+| Parent Span Id                                    | `ai.operation.parentId`  |                                                                                                     |
+| `SpanKind::Server` + `http.method` + `http.route` | `ai.operation.name`      | The name of the operation becomes `METHOD /the/route`.                                              |
+| `enduser.id`                                      | `ai.user.authUserId`     |                                                                                                     |
+| `service.name` + `service.namespace`              | `ai.cloud.role`          | The role becomes `NAMESPACE.NAME`.                                                                  |
+| `service.instance.id`                             | `ai.cloud.roleInstance`  |                                                                                                     |
+| `service.version`                                 | `ai.application.ver`     |                                                                                                     |
+| `telemetry.sdk.name`                              | `ai.internal.sdkVersion` |                                                                                                     |
+| `ai.*`                                            | `ai.*`                   | All other OpenTelemetry attributes that begin with `ai.` are copied into the AppInsights tags bag.  |
+
 ### Events
 
 Events are converted into Exception telemetry if the event name equals `"exception"` (see

--- a/README.md
+++ b/README.md
@@ -109,20 +109,6 @@ All other attributes are directly converted to custom properties.
 
 For Requests the attributes `http.method` and `http.route` override the Name.
 
-#### Automatic Attribute Mappings
-
-| OpenTelemetry Attribute                           | AppInsights Tag          | Notes                                                                                               |
-|---------------------------------------------------|--------------------------|-----------------------------------------------------------------------------------------------------|
-| Span Id                                           | `ai.operation.id`        |                                                                                                     |
-| Parent Span Id                                    | `ai.operation.parentId`  |                                                                                                     |
-| `SpanKind::Server` + `http.method` + `http.route` | `ai.operation.name`      | The name of the operation becomes `METHOD /the/route`.                                              |
-| `enduser.id`                                      | `ai.user.authUserId`     |                                                                                                     |
-| `service.name` + `service.namespace`              | `ai.cloud.role`          | The role becomes `NAMESPACE.NAME`.                                                                  |
-| `service.instance.id`                             | `ai.cloud.roleInstance`  |                                                                                                     |
-| `service.version`                                 | `ai.application.ver`     |                                                                                                     |
-| `telemetry.sdk.name`                              | `ai.internal.sdkVersion` |                                                                                                     |
-| `ai.*`                                            | `ai.*`                   | All other OpenTelemetry attributes that begin with `ai.` are copied into the AppInsights tags bag.  |
-
 ### Events
 
 Events are converted into Exception telemetry if the event name equals `"exception"` (see

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,48 +74,36 @@
 //! [trace]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/trace/semantic_conventions
 //! [resource]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/resource/semantic_conventions
 //!
-//! | OpenTelemetry attribute key                    | Application Insights field     |
-//! | ---------------------------------------------- | ------------------------------ |
-//! | `service.version`                              | Context: Application version   |
-//! | `enduser.id`                                   | Context: Authenticated user id |
-//! | `service.namespace` + `service.name`           | Context: Cloud role            |
-//! | `service.instance.id`                          | Context: Cloud role instance   |
-//! | `telemetry.sdk.name` + `telemetry.sdk.version` | Context: Internal SDK version  |
-//! | `http.url`                                     | Dependency Data                |
-//! | `db.statement`                                 | Dependency Data                |
-//! | `http.host`                                    | Dependency Target              |
-//! | `net.peer.name` + `net.peer.port`              | Dependency Target              |
-//! | `net.peer.ip` + `net.peer.port`                | Dependency Target              |
-//! | `db.name`                                      | Dependency Target              |
-//! | `http.status_code`                             | Dependency Result code         |
-//! | `db.system`                                    | Dependency Type                |
-//! | `messaging.system`                             | Dependency Type                |
-//! | `rpc.system`                                   | Dependency Type                |
-//! | `"HTTP"` if any `http.` attribute exists       | Dependency Type                |
-//! | `"DB"` if any `db.` attribute exists           | Dependency Type                |
-//! | `http.url`                                     | Request Url                    |
-//! | `http.scheme` + `http.host` + `http.target`    | Request Url                    |
-//! | `http.client_ip`                               | Request Source                 |
-//! | `net.peer.ip`                                  | Request Source                 |
-//! | `http.status_code`                             | Request Response code          |
-//!
+//! | OpenTelemetry attribute key                       | Application Insights field                               |
+//! | ------------------------------------------------- | -----------------------------------------------------    |
+//! | `service.version`                                 | Context: Application version (`ai.application.ver`)      |
+//! | `enduser.id`                                      | Context: Authenticated user id (`ai.user.authUserId`)    |
+//! | `service.namespace` + `service.name`              | Context: Cloud role (`ai.cloud.role`)                    |
+//! | `service.instance.id`                             | Context: Cloud role instance (`ai.cloud.roleInstance`)   |
+//! | `telemetry.sdk.name` + `telemetry.sdk.version`    | Context: Internal SDK version (`ai.internal.sdkVersion`) |
+//! | `SpanKind::Server` + `http.method` + `http.route` | Context: Operation Name (`ai.operation.name`)            |
+//! | `ai.*`                                            | Context: AppInsights Tag (`ai.*`)                        |
+//! | `http.url`                                        | Dependency Data                                          |
+//! | `db.statement`                                    | Dependency Data                                          |
+//! | `http.host`                                       | Dependency Target                                        |
+//! | `net.peer.name` + `net.peer.port`                 | Dependency Target                                        |
+//! | `net.peer.ip` + `net.peer.port`                   | Dependency Target                                        |
+//! | `db.name`                                         | Dependency Target                                        |
+//! | `http.status_code`                                | Dependency Result code                                   |
+//! | `db.system`                                       | Dependency Type                                          |
+//! | `messaging.system`                                | Dependency Type                                          |
+//! | `rpc.system`                                      | Dependency Type                                          |
+//! | `"HTTP"` if any `http.` attribute exists          | Dependency Type                                          |
+//! | `"DB"` if any `db.` attribute exists              | Dependency Type                                          |
+//! | `http.url`                                        | Request Url                                              |
+//! | `http.scheme` + `http.host` + `http.target`       | Request Url                                              |
+//! | `http.client_ip`                                  | Request Source                                           |
+//! | `net.peer.ip`                                     | Request Source                                           |
+//! | `http.status_code`                                | Request Response code                                    |
+//!   
 //! All other attributes are directly converted to custom properties.
 //!
 //! For Requests the attributes `http.method` and `http.route` override the Name.
-//!
-//! #### Automatic Attribute Mappings
-//!
-//! | OpenTelemetry Attribute                           | AppInsights Tag          | Notes                                                                                               |
-//! |---------------------------------------------------|--------------------------|-----------------------------------------------------------------------------------------------------|
-//! | Trace Id                                           | `ai.operation.id`        |                                                                                                     |
-//! | Parent Span Id                                    | `ai.operation.parentId`  |                                                                                                     |
-//! | `SpanKind::Server` + `http.method` + `http.route` | `ai.operation.name`      | The name of the operation becomes `METHOD /the/route`.                                              |
-//! | `enduser.id`                                      | `ai.user.authUserId`     |                                                                                                     |
-//! | `service.name` + `service.namespace`              | `ai.cloud.role`          | The role becomes `NAMESPACE.NAME`.                                                                  |
-//! | `service.instance.id`                             | `ai.cloud.roleInstance`  |                                                                                                     |
-//! | `service.version`                                 | `ai.application.ver`     |                                                                                                     |
-//! | `telemetry.sdk.name`                              | `ai.internal.sdkVersion` |                                                                                                     |
-//! | `ai.*`                                            | `ai.*`                   | All other OpenTelemetry attributes that begin with `ai.` are copied into the AppInsights tags bag.  |
 //!
 //! ## Events
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,20 @@
 //!
 //! For Requests the attributes `http.method` and `http.route` override the Name.
 //!
+//! #### Automatic Attribute Mappings
+//!
+//! | OpenTelemetry Attribute                           | AppInsights Tag          | Notes                                                                                               |
+//! |---------------------------------------------------|--------------------------|-----------------------------------------------------------------------------------------------------|
+//! | Trace Id                                           | `ai.operation.id`        |                                                                                                     |
+//! | Parent Span Id                                    | `ai.operation.parentId`  |                                                                                                     |
+//! | `SpanKind::Server` + `http.method` + `http.route` | `ai.operation.name`      | The name of the operation becomes `METHOD /the/route`.                                              |
+//! | `enduser.id`                                      | `ai.user.authUserId`     |                                                                                                     |
+//! | `service.name` + `service.namespace`              | `ai.cloud.role`          | The role becomes `NAMESPACE.NAME`.                                                                  |
+//! | `service.instance.id`                             | `ai.cloud.roleInstance`  |                                                                                                     |
+//! | `service.version`                                 | `ai.application.ver`     |                                                                                                     |
+//! | `telemetry.sdk.name`                              | `ai.internal.sdkVersion` |                                                                                                     |
+//! | `ai.*`                                            | `ai.*`                   | All other OpenTelemetry attributes that begin with `ai.` are copied into the AppInsights tags bag.  |
+//!
 //! ## Events
 //!
 //! Events are converted into Exception telemetry if the event name equals `"exception"` (see

--- a/src/models/context_tag_keys.rs
+++ b/src/models/context_tag_keys.rs
@@ -1,6 +1,6 @@
 use once_cell::sync::Lazy;
 use serde::{ser::Serializer, Serialize};
-use std::collections::{BTreeMap};
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct ContextTagKey {
@@ -200,7 +200,10 @@ pub(crate) static TAG_KEY_LOOKUP: Lazy<BTreeMap<&'static str, ContextTagKey>> = 
         ("ai.operation.name", OPERATION_NAME),
         ("ai.operation.parentId", OPERATION_PARENT_ID),
         ("ai.operation.syntheticSource", OPERATION_SYNTHETIC_SOURCE),
-        ("ai.operation.correlationVector", OPERATION_CORRELATION_VECTOR),
+        (
+            "ai.operation.correlationVector",
+            OPERATION_CORRELATION_VECTOR,
+        ),
         ("ai.session.id", SESSION_ID),
         ("ai.session.isFirst", SESSION_IS_FIRST),
         ("ai.user.accountId", USER_ACCOUNT_ID),
@@ -210,6 +213,8 @@ pub(crate) static TAG_KEY_LOOKUP: Lazy<BTreeMap<&'static str, ContextTagKey>> = 
         ("ai.cloud.roleInstance", CLOUD_ROLE_INSTANCE),
         ("ai.internal.sdkVersion", INTERNAL_SDK_VERSION),
         ("ai.internal.agentVersion", INTERNAL_AGENT_VERSION),
-        ("ai.internal.nodeName", INTERNAL_NODE_NAME)
-    ].into_iter().collect()
+        ("ai.internal.nodeName", INTERNAL_NODE_NAME),
+    ]
+    .into_iter()
+    .collect()
 });

--- a/src/models/context_tag_keys.rs
+++ b/src/models/context_tag_keys.rs
@@ -1,5 +1,6 @@
+use once_cell::sync::Lazy;
 use serde::{ser::Serializer, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct ContextTagKey {
@@ -181,3 +182,34 @@ impl Tags {
         self.0.get(key)
     }
 }
+
+pub(crate) static TAG_KEY_LOOKUP: Lazy<BTreeMap<&'static str, ContextTagKey>> = Lazy::new(|| {
+    vec![
+        ("ai.application.ver", APPLICATION_VERSION),
+        ("ai.device.id", DEVICE_ID),
+        ("ai.device.locale", DEVICE_LOCALE),
+        ("ai.device.model", DEVICE_MODEL),
+        ("ai.device.oemName", DEVICE_OEM_NAME),
+        ("ai.device.osVersion", DEVICE_OS_VERSION),
+        ("ai.device.type", DEVICE_TYPE),
+        ("ai.location.ip", LOCATION_IP),
+        ("ai.location.country", LOCATION_COUNTRY),
+        ("ai.location.province", LOCATION_PROVINCE),
+        ("ai.location.city", LOCATION_CITY),
+        ("ai.operation.id", OPERATION_ID),
+        ("ai.operation.name", OPERATION_NAME),
+        ("ai.operation.parentId", OPERATION_PARENT_ID),
+        ("ai.operation.syntheticSource", OPERATION_SYNTHETIC_SOURCE),
+        ("ai.operation.correlationVector", OPERATION_CORRELATION_VECTOR),
+        ("ai.session.id", SESSION_ID),
+        ("ai.session.isFirst", SESSION_IS_FIRST),
+        ("ai.user.accountId", USER_ACCOUNT_ID),
+        ("ai.user.id", USER_ID),
+        ("ai.user.authUserId", USER_AUTH_USER_ID),
+        ("ai.cloud.role", CLOUD_ROLE),
+        ("ai.cloud.roleInstance", CLOUD_ROLE_INSTANCE),
+        ("ai.internal.sdkVersion", INTERNAL_SDK_VERSION),
+        ("ai.internal.agentVersion", INTERNAL_AGENT_VERSION),
+        ("ai.internal.nodeName", INTERNAL_NODE_NAME)
+    ].into_iter().collect()
+});

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -1,6 +1,12 @@
-use crate::{convert::{span_id_to_string, trace_id_to_string}, models::context_tag_keys::TAG_KEY_LOOKUP};
 use crate::models::context_tag_keys::{self as tags, Tags};
-use opentelemetry::{exporter::trace::SpanData, trace::{SpanId, SpanKind}};
+use crate::{
+    convert::{span_id_to_string, trace_id_to_string},
+    models::context_tag_keys::TAG_KEY_LOOKUP,
+};
+use opentelemetry::{
+    exporter::trace::SpanData,
+    trace::{SpanId, SpanKind},
+};
 use opentelemetry_semantic_conventions as semcov;
 
 pub(crate) fn get_tags_for_span(span: &SpanData) -> Tags {
@@ -9,20 +15,20 @@ pub(crate) fn get_tags_for_span(span: &SpanData) -> Tags {
     // First, allow the user to explicitly express tags with attributes that start with `ai.`
     // These attributes do not collide with any opentelemetry semantic conventions, so it is
     // assumed that the user intends for them to be a part of the `tags` portion of the envelope.
-    let ai_tags_iter = span.attributes.iter().filter(|a| a.0.as_str().starts_with("ai."));
+    let ai_tags_iter = span
+        .attributes
+        .iter()
+        .filter(|a| a.0.as_str().starts_with("ai."));
     for ai_tag in ai_tags_iter {
         if let Some(ctk) = TAG_KEY_LOOKUP.get(ai_tag.0.as_str()) {
-            map.insert(
-                ctk.clone(), 
-                ai_tag.1.to_string()
-            );
+            map.insert(ctk.clone(), ai_tag.1.to_string());
         }
     }
 
     // Set the operation id and operation parent id.
     map.insert(
         tags::OPERATION_ID,
-        span_id_to_string(span.span_context.span_id()),
+        trace_id_to_string(span.span_context.trace_id()),
     );
     if span.parent_span_id != SpanId::invalid() {
         map.insert(


### PR DESCRIPTION
This addresses #25 

Generally, this makes a few changes:
* Adds `once_cell` to dependencies (could be changed to phf?): this allows for the creation of a static map.
* Adds a static map from `&'static str` => `ContextTagKey`: this allows us to look up a `ContextTagKey` from the string in a `Key` part of an OpenTelemetry `KeyValue` attribute.
* Updated `get_tags_for_span`: the map of tags in this method now looks for OpenTelemetry attributes that begin with `ai.`.  Then, the `ContextTagKey` for that key is looked up via the static map.  If it does not exist, it is ignored.  If it exists, that `ContextTagKey` is inserted into the tags map with the value from the OT attribute.
* Adds a section to the README which explicitly identifies the default mappings that occur under the hood.