### PR TITLE
Support rustls with reqwest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- New feature flags for using `rustls` with the `reqwest` clients instead of `nativetls`
+
 ## [0.11.0] - 2021-01-22
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,10 @@ exclude = [
 ]
 
 [features]
-reqwest-blocking-client = ["reqwest", "reqwest/blocking"]
-reqwest-client = ["reqwest", "opentelemetry/tokio-support"]
+reqwest-blocking-client = ["reqwest", "reqwest/native-tls", "reqwest/blocking"]
+reqwest-blocking-client-rustls = ["reqwest", "reqwest/rustls-tls", "reqwest/blocking"]
+reqwest-client = ["reqwest", "reqwest/native-tls", "opentelemetry/tokio-support"]
+reqwest-client-rustls = ["reqwest", "reqwest/rustls-tls", "opentelemetry/tokio-support"]
 surf-client = ["surf"]
 
 [dependencies]
@@ -31,7 +33,7 @@ http = "0.2"
 thiserror = "1"
 opentelemetry = "0.12"
 opentelemetry-semantic-conventions = "0.4"
-reqwest = { version = "0.11", optional = true }
+reqwest = { version = "0.11", optional = true, default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 surf = { version = "2", optional = true }

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -1,7 +1,12 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use http::{Request, Response};
-#[cfg(any(feature = "reqwest-blocking-client", feature = "reqwest-client"))]
+#[cfg(any(
+    feature = "reqwest-blocking-client",
+    feature = "reqwest-client",
+    feature = "reqwest-blocking-client-rustls",
+    feature = "reqwest-client-rustls",
+))]
 use std::convert::TryInto;
 use std::fmt::Debug;
 
@@ -22,8 +27,8 @@ pub trait HttpClient: Debug + Send + Sync {
 
 /// `HttpClient` implementation for `reqwest::Client`
 ///
-/// Requires the **reqwest-client** feature.
-#[cfg(feature = "reqwest-client")]
+/// Requires the **reqwest-client** or **reqwest-client-rustls** feature.
+#[cfg(any(feature = "reqwest-client", feature = "reqwest-client-rustls"))]
 #[async_trait]
 impl HttpClient for reqwest::Client {
     async fn send(&self, request: Request<Vec<u8>>) -> Result<Response<Bytes>, BoxError> {
@@ -36,8 +41,11 @@ impl HttpClient for reqwest::Client {
 
 /// `HttpClient` implementation for `reqwest::blocking::Client`
 ///
-/// Requires the **reqwest-blocking-client** feature.
-#[cfg(feature = "reqwest-blocking-client")]
+/// Requires the **reqwest-blocking-client** or **reqwest-blocking-client-rustls** feature.
+#[cfg(any(
+    feature = "reqwest-blocking-client",
+    feature = "reqwest-blocking-client-rustls"
+))]
 #[async_trait]
 impl HttpClient for reqwest::blocking::Client {
     async fn send(&self, request: Request<Vec<u8>>) -> Result<Response<Bytes>, BoxError> {


### PR DESCRIPTION
Adds two new feature flags `reqwest-client-rustls` and
`reqwest-client-blocking-rustls` to allow users of the crate to avoid a
dependency on nativetls when using the reqwest clients.