### PR TITLE
chore(deps): Update to OpenTelemetry 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ bytes = "1"
 chrono = "0.4"
 http = "0.2"
 thiserror = "1"
-opentelemetry = "0.13"
-opentelemetry-semantic-conventions = "0.5"
+opentelemetry = "0.14"
+opentelemetry-semantic-conventions = "0.6"
 reqwest = { version = "0.11", optional = true, default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -43,10 +43,10 @@ once_cell = "1"
 async-std = { version = "1.9.0", features = ["attributes"] }
 backtrace = "0.3.56"
 env_logger = "0.8.3"
-opentelemetry = { version = "0.13.0", features = ["rt-tokio"] }
+opentelemetry = { version = "0.14.0", features = ["rt-tokio"] }
 opentelemetry-application-insights = { path = ".", features = ["reqwest-client", "reqwest-blocking-client"] }
 test-case = "1.1.0"
-tokio = { version = "1.4.0", features = ["rt", "macros", "process", "time"] }
+tokio = { version = "1.6.0", features = ["rt", "macros", "process", "time"] }
 version-sync = "0.9.2"
 
 [package.metadata.docs.rs]

--- a/examples/opentelemetry.rs
+++ b/examples/opentelemetry.rs
@@ -14,7 +14,7 @@ use tokio::time::sleep;
 
 async fn spawn_children(n: u32, process_name: String) {
     let tracer = global::tracer("spawn_children");
-    let span = tracer.start("spawn_children");
+    let mut span = tracer.start("spawn_children");
     span.set_attribute(Key::new("n").i64(n.into()));
     span.set_attribute(Key::new("process_name").string(process_name.clone()));
     let cx = Context::current_with_span(span);
@@ -27,7 +27,7 @@ async fn spawn_children(n: u32, process_name: String) {
 
 async fn spawn_child_process(process_name: &str) {
     let tracer = global::tracer("spawn_child_process");
-    let span = tracer
+    let mut span = tracer
         .span_builder("spawn_child_process")
         .with_kind(SpanKind::Client)
         .start(&tracer);
@@ -54,7 +54,7 @@ async fn spawn_child_process(process_name: &str) {
 
 async fn run_in_child_process() {
     let tracer = global::tracer("run_in_child_process");
-    let span = tracer.start("run_in_child_process");
+    let mut span = tracer.start("run_in_child_process");
     span.add_event("leaf fn".into(), vec![]);
     sleep(Duration::from_millis(50)).await
 }

--- a/src/models/sanitize.rs
+++ b/src/models/sanitize.rs
@@ -18,6 +18,12 @@ macro_rules! limited_len_string {
             }
         }
 
+        impl <'a> From<std::borrow::Cow<'a, str>> for $name {
+            fn from(s: std::borrow::Cow<'a, str>) -> Self {
+                Self(String::from(&s[0..std::cmp::min(s.len(), $len)]))
+            }
+        }
+
         impl From<&opentelemetry::Value> for $name {
             fn from(v: &opentelemetry::Value) -> Self {
                 v.as_str().into_owned().into()


### PR DESCRIPTION
This PR updates to the latest version of OpenTelemetry and makes some changes necessary to support that. I feel like there may be room to improve the `Resource.merge` method usage when we're dealing with `Option<Arc<Resource>>` types, but this seems to work fine without any bigger changes.