### PR TITLE
Automated test for http request content

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,13 +51,13 @@ backtrace = "0.3.60"
 doc-comment = "0.3.3"
 env_logger = "0.9.0"
 insta = "1.10.0"
-opentelemetry = { version = "0.17", features = ["rt-tokio"] }
+opentelemetry = { version = "0.17", features = ["rt-async-std", "rt-tokio"] }
 opentelemetry-application-insights = { path = ".", features = ["reqwest-client", "reqwest-blocking-client"] }
 rand = "0.8.4"
 regex = "1.5.4"
 surf = "2.2.0"
 test-case = "1.1.0"
-tokio = { version = "1.7.0", features = ["rt", "macros", "process", "time"] }
+tokio = { version = "1.7.0", features = ["rt", "rt-multi-thread", "macros", "process", "time"] }
 version-sync = { version = "0.9.2", default-features = false, features = ["html_root_url_updated", "contains_regex"] }
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,11 @@ async-std = { version = "1.9.0", features = ["attributes"] }
 backtrace = "0.3.60"
 doc-comment = "0.3.3"
 env_logger = "0.9.0"
+insta = "1.10.0"
 opentelemetry = { version = "0.17", features = ["rt-tokio"] }
 opentelemetry-application-insights = { path = ".", features = ["reqwest-client", "reqwest-blocking-client"] }
 rand = "0.8.4"
+regex = "1.5.4"
 surf = "2.2.0"
 test-case = "1.1.0"
 tokio = { version = "1.7.0", features = ["rt", "macros", "process", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,19 +46,19 @@ thiserror = "1"
 ureq = { version = "2", optional = true }
 
 [dev-dependencies]
-async-std = { version = "1.9.0", features = ["attributes"] }
-backtrace = "0.3.60"
+async-std = { version = "1.10.0", features = ["attributes"] }
+backtrace = "0.3.64"
 doc-comment = "0.3.3"
 env_logger = "0.9.0"
-insta = "1.10.0"
+insta = "1.12.0"
 opentelemetry = { version = "0.17", features = ["rt-async-std", "rt-tokio"] }
 opentelemetry-application-insights = { path = ".", features = ["reqwest-client", "reqwest-blocking-client"] }
 rand = "0.8.4"
 regex = "1.5.4"
-surf = "2.2.0"
-test-case = "1.1.0"
-tokio = { version = "1.7.0", features = ["rt", "rt-multi-thread", "macros", "process", "time"] }
-version-sync = { version = "0.9.2", default-features = false, features = ["html_root_url_updated", "contains_regex"] }
+surf = "2.3.2"
+test-case = "1.2.1"
+tokio = { version = "1.16.1", features = ["rt", "rt-multi-thread", "macros", "process", "time"] }
+version-sync = { version = "0.9.4", default-features = false, features = ["html_root_url_updated", "contains_regex"] }
 
 [badges]
 github = { repository = "frigus02/opentelemetry-application-insights", workflow = "CI" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,13 +51,13 @@ backtrace = "0.3.64"
 doc-comment = "0.3.3"
 env_logger = "0.9.0"
 insta = "1.12.0"
-opentelemetry = { version = "0.17", features = ["rt-async-std", "rt-tokio"] }
+opentelemetry = { version = "0.17", features = ["rt-async-std", "rt-tokio", "rt-tokio-current-thread"] }
 opentelemetry-application-insights = { path = ".", features = ["reqwest-client", "reqwest-blocking-client"] }
 rand = "0.8.4"
 regex = "1.5.4"
 surf = "2.3.2"
 test-case = "1.2.1"
-tokio = { version = "1.16.1", features = ["rt", "rt-multi-thread", "macros", "process", "time"] }
+tokio = { version = "1.16.1", features = ["rt", "macros", "process", "time"] }
 version-sync = { version = "0.9.4", default-features = false, features = ["html_root_url_updated", "contains_regex"] }
 
 [badges]

--- a/examples/attributes.rs
+++ b/examples/attributes.rs
@@ -8,10 +8,7 @@ use std::env;
 
 fn log() {
     get_active_span(|span| {
-        span.add_event(
-            "An event!".to_string(),
-            vec![KeyValue::new("happened", true)],
-        );
+        span.add_event("An event!", vec![KeyValue::new("happened", true)]);
     })
 }
 

--- a/tests/http_requests.rs
+++ b/tests/http_requests.rs
@@ -1,63 +1,30 @@
-use async_trait::async_trait;
-use bytes::Bytes;
-use http::{Request, Response};
+//! Snapshot tests for generated HTTP requests
+//!
+//! # Update snapshots
+//!
+//! ```
+//! INSTA_UPDATE=always cargo test
+//! ```
+
+use format::requests_to_string;
 use opentelemetry::{
     sdk::{trace::Config, Resource},
     trace::{get_active_span, SpanKind, Tracer, TracerProvider},
     KeyValue,
 };
 use opentelemetry_application_insights::new_pipeline;
-use opentelemetry_http::{HttpClient, HttpError};
 use opentelemetry_semantic_conventions as semcov;
-use regex::Regex;
-use std::sync::{Arc, Mutex};
+use recording_client::record;
+use tick::{AsyncStdTick, NoTick, TokioTick};
+
+// Fake instrumentation key (this is a random uuid)
+const INSTRUMENTATION_KEY: &str = "0fdcec70-0ce5-4085-89d9-9ae8ead9af66";
 
 #[test]
-fn http_requests() {
-    let requests = create_traces()
-        .into_iter()
-        .map(request_to_string)
-        .collect::<Vec<_>>()
-        .join("\n\n\n");
-    insta::assert_snapshot!(requests);
-}
-
-#[derive(Debug, Default, Clone)]
-struct RecordingClient {
-    requests: Arc<Mutex<Vec<Request<Vec<u8>>>>>,
-}
-
-impl RecordingClient {
-    fn read_and_clear(&self) -> Vec<Request<Vec<u8>>> {
-        self.requests
-            .lock()
-            .expect("requests mutex is healthy")
-            .split_off(0)
-    }
-}
-
-#[async_trait]
-impl HttpClient for RecordingClient {
-    async fn send(&self, req: Request<Vec<u8>>) -> Result<Response<Bytes>, HttpError> {
-        self.requests
-            .lock()
-            .expect("requests mutex is healthy")
-            .push(req);
-        Ok(Response::builder()
-            .status(200)
-            .body(Bytes::from("{}"))
-            .expect("response is fell formed"))
-    }
-}
-
-fn create_traces() -> Vec<Request<Vec<u8>>> {
-    let client = RecordingClient::default();
-
-    {
+fn traces_simple() {
+    let requests = record(NoTick, |client| {
         // Fake instrumentation key (this is a random uuid)
-        let instrumentation_key = "0fdcec70-0ce5-4085-89d9-9ae8ead9af66".to_string();
-
-        let client_provider = new_pipeline(instrumentation_key.clone())
+        let client_provider = new_pipeline(INSTRUMENTATION_KEY.into())
             .with_client(client.clone())
             .with_trace_config(Config::default().with_resource(Resource::new(vec![
                 semcov::resource::SERVICE_NAMESPACE.string("test"),
@@ -66,8 +33,8 @@ fn create_traces() -> Vec<Request<Vec<u8>>> {
             .build_simple();
         let client_tracer = client_provider.tracer("test");
 
-        let server_provider = new_pipeline(instrumentation_key)
-            .with_client(client.clone())
+        let server_provider = new_pipeline(INSTRUMENTATION_KEY.into())
+            .with_client(client)
             .with_trace_config(Config::default().with_resource(Resource::new(vec![
                 semcov::resource::SERVICE_NAMESPACE.string("test"),
                 semcov::resource::SERVICE_NAME.string("server"),
@@ -108,43 +75,168 @@ fn create_traces() -> Vec<Request<Vec<u8>>> {
                 });
             });
         });
+    });
+    let traces_simple = requests_to_string(requests);
+    insta::assert_snapshot!(traces_simple);
+}
+
+#[async_std::test]
+async fn traces_batch_async_std() {
+    let requests = record(AsyncStdTick, |client| {
+        let tracer_provider = new_pipeline(INSTRUMENTATION_KEY.into())
+            .with_client(client)
+            .build_batch(opentelemetry::runtime::AsyncStd);
+        let tracer = tracer_provider.tracer("test");
+
+        tracer.in_span("async-std", |_cx| {});
+    });
+    let traces_batch_async_std = requests_to_string(requests);
+    insta::assert_snapshot!(traces_batch_async_std);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn traces_batch_tokio() {
+    let requests = record(TokioTick, |client| {
+        let tracer_provider = new_pipeline(INSTRUMENTATION_KEY.into())
+            .with_client(client)
+            .build_batch(opentelemetry::runtime::Tokio);
+        let tracer = tracer_provider.tracer("test");
+
+        tracer.in_span("tokio", |_cx| {});
+    });
+    let traces_batch_tokio = requests_to_string(requests);
+    insta::assert_snapshot!(traces_batch_tokio);
+}
+
+mod recording_client {
+    use super::tick::Tick;
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use http::{Request, Response};
+    use opentelemetry_http::{HttpClient, HttpError};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Debug, Clone)]
+    pub struct RecordingClient {
+        requests: Arc<Mutex<Vec<Request<Vec<u8>>>>>,
+        tick: Arc<dyn Tick>,
     }
 
-    client.read_and_clear()
+    #[async_trait]
+    impl HttpClient for RecordingClient {
+        async fn send(&self, req: Request<Vec<u8>>) -> Result<Response<Bytes>, HttpError> {
+            self.tick.tick().await;
+            self.requests
+                .lock()
+                .expect("requests mutex is healthy")
+                .push(req);
+            Ok(Response::builder()
+                .status(200)
+                .body(Bytes::from("{}"))
+                .expect("response is fell formed"))
+        }
+    }
+
+    pub fn record(
+        tick: impl Tick + 'static,
+        generate_fn: impl Fn(RecordingClient),
+    ) -> Vec<Request<Vec<u8>>> {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        generate_fn(RecordingClient {
+            requests: Arc::clone(&requests),
+            tick: Arc::new(tick),
+        });
+        Arc::try_unwrap(requests)
+            .expect("client is dropped everywhere")
+            .into_inner()
+            .expect("requests mutex is healthy")
+    }
 }
 
-fn request_to_string(req: Request<Vec<u8>>) -> String {
-    let method = req.method();
-    let path = req.uri().path_and_query().expect("path exists");
-    let version = format!("{:?}", req.version());
-    let host = req.uri().authority().expect("authority exists");
-    let headers = req
-        .headers()
-        .into_iter()
-        .map(|(name, value)| {
-            let value = value.to_str().expect("header value is valid string");
-            format!("{name}: {value}")
+mod tick {
+    use async_trait::async_trait;
+    use std::{fmt::Debug, time::Duration};
+
+    #[async_trait]
+    pub trait Tick: Debug + Send + Sync {
+        async fn tick(&self);
+    }
+
+    #[derive(Debug)]
+    pub struct NoTick;
+
+    #[async_trait]
+    impl Tick for NoTick {
+        async fn tick(&self) {}
+    }
+
+    #[derive(Debug)]
+    pub struct AsyncStdTick;
+
+    #[async_trait]
+    impl Tick for AsyncStdTick {
+        async fn tick(&self) {
+            async_std::task::sleep(Duration::from_millis(1)).await;
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct TokioTick;
+
+    #[async_trait]
+    impl Tick for TokioTick {
+        async fn tick(&self) {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    }
+}
+
+mod format {
+    use http::Request;
+    use regex::Regex;
+
+    pub fn requests_to_string(requests: Vec<Request<Vec<u8>>>) -> String {
+        requests
+            .into_iter()
+            .map(request_to_string)
+            .collect::<Vec<_>>()
+            .join("\n\n\n")
+    }
+
+    fn request_to_string(req: Request<Vec<u8>>) -> String {
+        let method = req.method();
+        let path = req.uri().path_and_query().expect("path exists");
+        let version = format!("{:?}", req.version());
+        let host = req.uri().authority().expect("authority exists");
+        let headers = req
+            .headers()
+            .into_iter()
+            .map(|(name, value)| {
+                let value = value.to_str().expect("header value is valid string");
+                format!("{name}: {value}")
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let body = strip_changing_values(&pretty_print_json(req.body()));
+        format!("{method} {path} {version}\nhost: {host}\n{headers}\n\n{body}")
+    }
+
+    fn strip_changing_values(body: &str) -> String {
+        let res = vec![
+            Regex::new(r#""(?P<field>time)": "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z""#)
+                .unwrap(),
+            Regex::new(r#""(?P<field>duration)": "\d+\.\d{2}:\d{2}:\d{2}\.\d{6}""#).unwrap(),
+            Regex::new(r#""(?P<field>id|ai\.operation\.parentId)": "[a-z0-9]{16}""#).unwrap(),
+            Regex::new(r#""(?P<field>ai\.operation\.id)": "[a-z0-9]{32}""#).unwrap(),
+        ];
+
+        res.into_iter().fold(body.into(), |body, re| {
+            re.replace_all(&body, r#""$field": "STRIPPED""#).into()
         })
-        .collect::<Vec<_>>()
-        .join("\n");
-    let body = strip_changing_values(&pretty_print_json(req.body()));
-    format!("{method} {path} {version}\nhost: {host}\n{headers}\n\n{body}")
-}
+    }
 
-fn strip_changing_values(body: &str) -> String {
-    let res = vec![
-        Regex::new(r#""(?P<field>time)": "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z""#).unwrap(),
-        Regex::new(r#""(?P<field>duration)": "\d+\.\d{2}:\d{2}:\d{2}\.\d{6}""#).unwrap(),
-        Regex::new(r#""(?P<field>id|ai\.operation\.parentId)": "[a-z0-9]{16}""#).unwrap(),
-        Regex::new(r#""(?P<field>ai\.operation\.id)": "[a-z0-9]{32}""#).unwrap(),
-    ];
-
-    res.into_iter().fold(body.into(), |body, re| {
-        re.replace_all(&body, r#""$field": "STRIPPED""#).into()
-    })
-}
-
-fn pretty_print_json(body: &[u8]) -> String {
-    let json: serde_json::Value = serde_json::from_slice(body).expect("body is valid json");
-    serde_json::to_string_pretty(&json).unwrap()
+    fn pretty_print_json(body: &[u8]) -> String {
+        let json: serde_json::Value = serde_json::from_slice(body).expect("body is valid json");
+        serde_json::to_string_pretty(&json).unwrap()
+    }
 }

--- a/tests/http_requests.rs
+++ b/tests/http_requests.rs
@@ -1,0 +1,150 @@
+use async_trait::async_trait;
+use bytes::Bytes;
+use http::{Request, Response};
+use opentelemetry::{
+    sdk::{trace::Config, Resource},
+    trace::{get_active_span, SpanKind, Tracer, TracerProvider},
+    KeyValue,
+};
+use opentelemetry_application_insights::new_pipeline;
+use opentelemetry_http::{HttpClient, HttpError};
+use opentelemetry_semantic_conventions as semcov;
+use regex::Regex;
+use std::sync::{Arc, Mutex};
+
+#[test]
+fn http_requests() {
+    let requests = create_traces()
+        .into_iter()
+        .map(request_to_string)
+        .collect::<Vec<_>>()
+        .join("\n\n\n");
+    insta::assert_snapshot!(requests);
+}
+
+#[derive(Debug, Default, Clone)]
+struct RecordingClient {
+    requests: Arc<Mutex<Vec<Request<Vec<u8>>>>>,
+}
+
+impl RecordingClient {
+    fn read_and_clear(&self) -> Vec<Request<Vec<u8>>> {
+        self.requests
+            .lock()
+            .expect("requests mutex is healthy")
+            .split_off(0)
+    }
+}
+
+#[async_trait]
+impl HttpClient for RecordingClient {
+    async fn send(&self, req: Request<Vec<u8>>) -> Result<Response<Bytes>, HttpError> {
+        self.requests
+            .lock()
+            .expect("requests mutex is healthy")
+            .push(req);
+        Ok(Response::builder()
+            .status(200)
+            .body(Bytes::from("{}"))
+            .expect("response is fell formed"))
+    }
+}
+
+fn create_traces() -> Vec<Request<Vec<u8>>> {
+    let client = RecordingClient::default();
+
+    {
+        // Fake instrumentation key (this is a random uuid)
+        let instrumentation_key = "0fdcec70-0ce5-4085-89d9-9ae8ead9af66".to_string();
+
+        let client_provider = new_pipeline(instrumentation_key.clone())
+            .with_client(client.clone())
+            .with_trace_config(Config::default().with_resource(Resource::new(vec![
+                semcov::resource::SERVICE_NAMESPACE.string("test"),
+                semcov::resource::SERVICE_NAME.string("client"),
+            ])))
+            .build_simple();
+        let client_tracer = client_provider.tracer("test");
+
+        let server_provider = new_pipeline(instrumentation_key)
+            .with_client(client.clone())
+            .with_trace_config(Config::default().with_resource(Resource::new(vec![
+                semcov::resource::SERVICE_NAMESPACE.string("test"),
+                semcov::resource::SERVICE_NAME.string("server"),
+            ])))
+            .build_simple();
+        let server_tracer = server_provider.tracer("test");
+
+        // An HTTP client make a request
+        let span = client_tracer
+            .span_builder("dependency")
+            .with_kind(SpanKind::Client)
+            .with_attributes(vec![
+                semcov::trace::ENDUSER_ID.string("marry"),
+                semcov::trace::NET_HOST_NAME.string("localhost"),
+                semcov::trace::NET_PEER_IP.string("10.1.2.4"),
+                semcov::trace::HTTP_URL.string("http://10.1.2.4/hello/world?name=marry"),
+                semcov::trace::HTTP_STATUS_CODE.string("200"),
+            ])
+            .start(&client_tracer);
+        client_tracer.with_span(span, |cx| {
+            // The server receives the request
+            let builder = server_tracer
+                .span_builder("request")
+                .with_kind(SpanKind::Server)
+                .with_attributes(vec![
+                    semcov::trace::ENDUSER_ID.string("marry"),
+                    semcov::trace::NET_HOST_NAME.string("localhost"),
+                    semcov::trace::NET_PEER_IP.string("10.1.2.3"),
+                    semcov::trace::HTTP_TARGET.string("/hello/world?name=marry"),
+                    semcov::trace::HTTP_STATUS_CODE.string("200"),
+                ]);
+            let span = server_tracer.build_with_context(builder, &cx);
+            server_tracer.with_span(span, |_cx| {
+                get_active_span(|span| {
+                    span.add_event("An event!", vec![KeyValue::new("happened", true)]);
+                    let error: Box<dyn std::error::Error> = "An error".into();
+                    span.record_exception_with_stacktrace(error.as_ref(), "a backtrace");
+                });
+            });
+        });
+    }
+
+    client.read_and_clear()
+}
+
+fn request_to_string(req: Request<Vec<u8>>) -> String {
+    let method = req.method();
+    let path = req.uri().path_and_query().expect("path exists");
+    let version = format!("{:?}", req.version());
+    let host = req.uri().authority().expect("authority exists");
+    let headers = req
+        .headers()
+        .into_iter()
+        .map(|(name, value)| {
+            let value = value.to_str().expect("header value is valid string");
+            format!("{name}: {value}")
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let body = strip_changing_values(&pretty_print_json(req.body()));
+    format!("{method} {path} {version}\nhost: {host}\n{headers}\n\n{body}")
+}
+
+fn strip_changing_values(body: &str) -> String {
+    let res = vec![
+        Regex::new(r#""(?P<field>time)": "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z""#).unwrap(),
+        Regex::new(r#""(?P<field>duration)": "\d+\.\d{2}:\d{2}:\d{2}\.\d{6}""#).unwrap(),
+        Regex::new(r#""(?P<field>id|ai\.operation\.parentId)": "[a-z0-9]{16}""#).unwrap(),
+        Regex::new(r#""(?P<field>ai\.operation\.id)": "[a-z0-9]{32}""#).unwrap(),
+    ];
+
+    res.into_iter().fold(body.into(), |body, re| {
+        re.replace_all(&body, r#""$field": "STRIPPED""#).into()
+    })
+}
+
+fn pretty_print_json(body: &[u8]) -> String {
+    let json: serde_json::Value = serde_json::from_slice(body).expect("body is valid json");
+    serde_json::to_string_pretty(&json).unwrap()
+}

--- a/tests/http_requests.rs
+++ b/tests/http_requests.rs
@@ -15,6 +15,7 @@ use opentelemetry::{
 use opentelemetry_application_insights::new_pipeline;
 use opentelemetry_semantic_conventions as semcov;
 use recording_client::record;
+use std::time::Duration;
 use tick::{AsyncStdTick, NoTick, TokioTick};
 
 // Fake instrumentation key (this is a random uuid)
@@ -74,6 +75,11 @@ fn traces_simple() {
                     span.record_exception_with_stacktrace(error.as_ref(), "a backtrace");
                 });
             });
+
+            // Force the server span to be sent before the client span. Without this on Jan's PC
+            // the server span gets sent after the client span, but on GitHub Actions it's the
+            // other way around.
+            std::thread::sleep(Duration::from_millis(1000));
         });
     });
     let traces_simple = requests_to_string(requests);

--- a/tests/snapshots/http_requests__http_requests.snap
+++ b/tests/snapshots/http_requests__http_requests.snap
@@ -1,0 +1,130 @@
+---
+source: tests/http_requests.rs
+assertion_line: 22
+expression: requests
+
+---
+POST /v2/track HTTP/1.1
+host: dc.services.visualstudio.com
+content-type: application/json
+
+[
+  {
+    "data": {
+      "baseData": {
+        "data": "http://10.1.2.4/hello/world?name=marry",
+        "duration": "STRIPPED",
+        "id": "STRIPPED",
+        "name": "dependency",
+        "properties": {
+          "enduser.id": "marry",
+          "http.status_code": "200",
+          "http.url": "http://10.1.2.4/hello/world?name=marry",
+          "net.host.name": "localhost",
+          "net.peer.ip": "10.1.2.4",
+          "service.name": "client",
+          "service.namespace": "test"
+        },
+        "resultCode": "200",
+        "target": "10.1.2.4",
+        "type": "HTTP",
+        "ver": 2
+      },
+      "baseType": "RemoteDependencyData"
+    },
+    "iKey": "0fdcec70-0ce5-4085-89d9-9ae8ead9af66",
+    "name": "Microsoft.ApplicationInsights.RemoteDependency",
+    "sampleRate": 100.0,
+    "tags": {
+      "ai.cloud.role": "test.client",
+      "ai.operation.id": "STRIPPED",
+      "ai.user.authUserId": "marry"
+    },
+    "time": "STRIPPED"
+  }
+]
+
+
+POST /v2/track HTTP/1.1
+host: dc.services.visualstudio.com
+content-type: application/json
+
+[
+  {
+    "data": {
+      "baseData": {
+        "duration": "STRIPPED",
+        "id": "STRIPPED",
+        "name": "request",
+        "properties": {
+          "enduser.id": "marry",
+          "http.status_code": "200",
+          "http.target": "/hello/world?name=marry",
+          "net.host.name": "localhost",
+          "net.peer.ip": "10.1.2.3",
+          "service.name": "server",
+          "service.namespace": "test"
+        },
+        "responseCode": "200",
+        "source": "10.1.2.3",
+        "success": true,
+        "url": "/hello/world?name=marry",
+        "ver": 2
+      },
+      "baseType": "RequestData"
+    },
+    "iKey": "0fdcec70-0ce5-4085-89d9-9ae8ead9af66",
+    "name": "Microsoft.ApplicationInsights.Request",
+    "sampleRate": 100.0,
+    "tags": {
+      "ai.cloud.role": "test.server",
+      "ai.operation.id": "STRIPPED",
+      "ai.operation.parentId": "STRIPPED",
+      "ai.user.authUserId": "marry"
+    },
+    "time": "STRIPPED"
+  },
+  {
+    "data": {
+      "baseData": {
+        "message": "An event!",
+        "properties": {
+          "happened": "true"
+        },
+        "ver": 2
+      },
+      "baseType": "MessageData"
+    },
+    "iKey": "0fdcec70-0ce5-4085-89d9-9ae8ead9af66",
+    "name": "Microsoft.ApplicationInsights.Message",
+    "sampleRate": 100.0,
+    "tags": {
+      "ai.operation.id": "STRIPPED",
+      "ai.operation.parentId": "STRIPPED"
+    },
+    "time": "STRIPPED"
+  },
+  {
+    "data": {
+      "baseData": {
+        "exceptions": [
+          {
+            "message": "An error",
+            "stack": "a backtrace",
+            "typeName": "<no type>"
+          }
+        ],
+        "ver": 2
+      },
+      "baseType": "ExceptionData"
+    },
+    "iKey": "0fdcec70-0ce5-4085-89d9-9ae8ead9af66",
+    "name": "Microsoft.ApplicationInsights.Exception",
+    "sampleRate": 100.0,
+    "tags": {
+      "ai.operation.id": "STRIPPED",
+      "ai.operation.parentId": "STRIPPED"
+    },
+    "time": "STRIPPED"
+  }
+]

--- a/tests/snapshots/http_requests__traces_batch_async_std.snap
+++ b/tests/snapshots/http_requests__traces_batch_async_std.snap
@@ -1,0 +1,36 @@
+---
+source: tests/http_requests.rs
+assertion_line: 131
+expression: traces_batch_async_std
+
+---
+POST /v2/track HTTP/1.1
+host: dc.services.visualstudio.com
+content-type: application/json
+
+[
+  {
+    "data": {
+      "baseData": {
+        "duration": "STRIPPED",
+        "id": "STRIPPED",
+        "name": "async-std",
+        "properties": {
+          "service.name": "unknown_service"
+        },
+        "resultCode": "0",
+        "type": "InProc",
+        "ver": 2
+      },
+      "baseType": "RemoteDependencyData"
+    },
+    "iKey": "0fdcec70-0ce5-4085-89d9-9ae8ead9af66",
+    "name": "Microsoft.ApplicationInsights.RemoteDependency",
+    "sampleRate": 100.0,
+    "tags": {
+      "ai.cloud.role": "unknown_service",
+      "ai.operation.id": "STRIPPED"
+    },
+    "time": "STRIPPED"
+  }
+]

--- a/tests/snapshots/http_requests__traces_batch_tokio.snap
+++ b/tests/snapshots/http_requests__traces_batch_tokio.snap
@@ -1,0 +1,36 @@
+---
+source: tests/http_requests.rs
+assertion_line: 145
+expression: traces_batch_tokio
+
+---
+POST /v2/track HTTP/1.1
+host: dc.services.visualstudio.com
+content-type: application/json
+
+[
+  {
+    "data": {
+      "baseData": {
+        "duration": "STRIPPED",
+        "id": "STRIPPED",
+        "name": "tokio",
+        "properties": {
+          "service.name": "unknown_service"
+        },
+        "resultCode": "0",
+        "type": "InProc",
+        "ver": 2
+      },
+      "baseType": "RemoteDependencyData"
+    },
+    "iKey": "0fdcec70-0ce5-4085-89d9-9ae8ead9af66",
+    "name": "Microsoft.ApplicationInsights.RemoteDependency",
+    "sampleRate": 100.0,
+    "tags": {
+      "ai.cloud.role": "unknown_service",
+      "ai.operation.id": "STRIPPED"
+    },
+    "time": "STRIPPED"
+  }
+]

--- a/tests/snapshots/http_requests__traces_simple.snap
+++ b/tests/snapshots/http_requests__traces_simple.snap
@@ -1,50 +1,9 @@
 ---
 source: tests/http_requests.rs
-assertion_line: 117
+assertion_line: 86
 expression: traces_simple
 
 ---
-POST /v2/track HTTP/1.1
-host: dc.services.visualstudio.com
-content-type: application/json
-
-[
-  {
-    "data": {
-      "baseData": {
-        "data": "http://10.1.2.4/hello/world?name=marry",
-        "duration": "STRIPPED",
-        "id": "STRIPPED",
-        "name": "dependency",
-        "properties": {
-          "enduser.id": "marry",
-          "http.status_code": "200",
-          "http.url": "http://10.1.2.4/hello/world?name=marry",
-          "net.host.name": "localhost",
-          "net.peer.ip": "10.1.2.4",
-          "service.name": "client",
-          "service.namespace": "test"
-        },
-        "resultCode": "200",
-        "target": "10.1.2.4",
-        "type": "HTTP",
-        "ver": 2
-      },
-      "baseType": "RemoteDependencyData"
-    },
-    "iKey": "0fdcec70-0ce5-4085-89d9-9ae8ead9af66",
-    "name": "Microsoft.ApplicationInsights.RemoteDependency",
-    "sampleRate": 100.0,
-    "tags": {
-      "ai.cloud.role": "test.client",
-      "ai.operation.id": "STRIPPED",
-      "ai.user.authUserId": "marry"
-    },
-    "time": "STRIPPED"
-  }
-]
-
-
 POST /v2/track HTTP/1.1
 host: dc.services.visualstudio.com
 content-type: application/json
@@ -124,6 +83,47 @@ content-type: application/json
     "tags": {
       "ai.operation.id": "STRIPPED",
       "ai.operation.parentId": "STRIPPED"
+    },
+    "time": "STRIPPED"
+  }
+]
+
+
+POST /v2/track HTTP/1.1
+host: dc.services.visualstudio.com
+content-type: application/json
+
+[
+  {
+    "data": {
+      "baseData": {
+        "data": "http://10.1.2.4/hello/world?name=marry",
+        "duration": "STRIPPED",
+        "id": "STRIPPED",
+        "name": "dependency",
+        "properties": {
+          "enduser.id": "marry",
+          "http.status_code": "200",
+          "http.url": "http://10.1.2.4/hello/world?name=marry",
+          "net.host.name": "localhost",
+          "net.peer.ip": "10.1.2.4",
+          "service.name": "client",
+          "service.namespace": "test"
+        },
+        "resultCode": "200",
+        "target": "10.1.2.4",
+        "type": "HTTP",
+        "ver": 2
+      },
+      "baseType": "RemoteDependencyData"
+    },
+    "iKey": "0fdcec70-0ce5-4085-89d9-9ae8ead9af66",
+    "name": "Microsoft.ApplicationInsights.RemoteDependency",
+    "sampleRate": 100.0,
+    "tags": {
+      "ai.cloud.role": "test.client",
+      "ai.operation.id": "STRIPPED",
+      "ai.user.authUserId": "marry"
     },
     "time": "STRIPPED"
   }

--- a/tests/snapshots/http_requests__traces_simple.snap
+++ b/tests/snapshots/http_requests__traces_simple.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/http_requests.rs
-assertion_line: 22
-expression: requests
+assertion_line: 117
+expression: traces_simple
 
 ---
 POST /v2/track HTTP/1.1


### PR DESCRIPTION
As of today I have manually tested every release to ensure to communication with Application Insights still works:

1. Run reqwest blocking example (test blocking)
2. Run reqwest example (test tokio)
3. Run surf example (test async-std)
4. Run opentelemetry example (test trace correlation)
5. Run attributes example (test attribute mapping)
6. Run metrics example (test metrics)
7. Check Azure Portal to ensure data shows up as intended

This is time consuming and error prone. It would be nice to automate those tests.

This is an attempt for it, which captures the HTTP requests this exporter would send to Azure and writes them to a snapshot file. Assuming Application Insights' behavior doesn't change this should be enough to ensure the integration works.

Metrics tests are still missing here. But metrics currently don't use the `HttpClient` trait because the exporter is synchronous. Maybe later.