### PR TITLE
gzip compression for requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Use gzip compression (`Content-Encoding: gzip`) for `POST /v2/track` HTTP request.
+
 ## [0.19.0] - 2022-01-23
 
 - Upgrade to `v0.17.0` of `opentelemetry`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ metrics = ["opentelemetry/metrics", "ureq"]
 async-trait = "0.1"
 bytes = "1"
 chrono = "0.4"
+flate2 = "1"
 http = "0.2"
 once_cell = "1"
 opentelemetry = "0.17"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -511,6 +511,13 @@ pub enum Error {
     #[error("serializing upload request failed with {0}")]
     UploadSerializeRequest(serde_json::Error),
 
+    /// Application Insights telemetry data failed serialize or compress. Telemetry reporting failed
+    /// because of this.
+    ///
+    /// Note: This is an error in this crate. If you spot this, please open an issue.
+    #[error("compressing upload request failed with {0}")]
+    UploadCompressRequest(std::io::Error),
+
     /// Application Insights telemetry response failed to deserialize from JSON.
     ///
     /// Telemetry reporting may have worked. But since we could not look into the response, we

--- a/tests/http_requests.rs
+++ b/tests/http_requests.rs
@@ -206,6 +206,7 @@ mod tick {
 }
 
 mod format {
+    use flate2::read::GzDecoder;
     use http::Request;
     use regex::Regex;
 
@@ -250,7 +251,9 @@ mod format {
     }
 
     fn pretty_print_json(body: &[u8]) -> String {
-        let json: serde_json::Value = serde_json::from_slice(body).expect("body is valid json");
+        let gzip_decoder = GzDecoder::new(body);
+        let json: serde_json::Value =
+            serde_json::from_reader(gzip_decoder).expect("body is valid json");
         serde_json::to_string_pretty(&json).unwrap()
     }
 }

--- a/tests/snapshots/http_requests__traces_batch_async_std.snap
+++ b/tests/snapshots/http_requests__traces_batch_async_std.snap
@@ -1,12 +1,13 @@
 ---
 source: tests/http_requests.rs
-assertion_line: 131
+assertion_line: 100
 expression: traces_batch_async_std
 
 ---
 POST /v2/track HTTP/1.1
 host: dc.services.visualstudio.com
 content-type: application/json
+content-encoding: gzip
 
 [
   {

--- a/tests/snapshots/http_requests__traces_batch_tokio.snap
+++ b/tests/snapshots/http_requests__traces_batch_tokio.snap
@@ -1,12 +1,13 @@
 ---
 source: tests/http_requests.rs
-assertion_line: 145
+assertion_line: 114
 expression: traces_batch_tokio
 
 ---
 POST /v2/track HTTP/1.1
 host: dc.services.visualstudio.com
 content-type: application/json
+content-encoding: gzip
 
 [
   {

--- a/tests/snapshots/http_requests__traces_simple.snap
+++ b/tests/snapshots/http_requests__traces_simple.snap
@@ -7,6 +7,7 @@ expression: traces_simple
 POST /v2/track HTTP/1.1
 host: dc.services.visualstudio.com
 content-type: application/json
+content-encoding: gzip
 
 [
   {
@@ -92,6 +93,7 @@ content-type: application/json
 POST /v2/track HTTP/1.1
 host: dc.services.visualstudio.com
 content-type: application/json
+content-encoding: gzip
 
 [
   {


### PR DESCRIPTION
See #46 

Seems to work correctly. Tested using:

- `cargo run --example opentelemetry`
- `cargo run --example metrics --features metric`

Todo:

- [x] Do HTTP tests work with this?
- [x] Does this have to be optional (opt-in or opt-out)? We allow custom endpoints? Is it possible they don't support gzip? Is it possible users want to turn off gzip compression to reduce CPU usage?
  - As far as I can tell the .NET SDK turns compression on by default and there is no opt-out. I think fewer configuration options are generally better. Having this always turned on sounds good to me.
- [x] Should we also support gzip responses (`Accept-Encoding: gzip`)? Does Application Insights even support that?
  - I tried calling the App Insights endpoint with `Accept-Encoding: gzip, deflate, br`. It doesn't use it for the response.