### PR TITLE
Custom events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Support sending `customEvents` (see [#53](https://github.com/frigus02/opentelemetry-application-insights/issues/53)).
+
 ## [0.22.0] - 2022-09-17
 
 - Upgrade to `v0.18.0` of `opentelemetry`.

--- a/examples/attributes.rs
+++ b/examples/attributes.rs
@@ -5,11 +5,24 @@ use opentelemetry::{
     },
     Context, KeyValue,
 };
+use opentelemetry_application_insights::attrs as ai;
 use std::env;
 
 fn log() {
     get_active_span(|span| {
         span.add_event("An event!", vec![KeyValue::new("happened", true)]);
+    })
+}
+
+fn custom() {
+    get_active_span(|span| {
+        span.add_event(
+            "ai.custom",
+            vec![
+                ai::CUSTOM_EVENT_NAME.string("A custom event!"),
+                KeyValue::new("some.data", 5),
+            ],
+        );
     })
 }
 
@@ -79,6 +92,7 @@ fn main() {
         {
             let _server_guard = mark_span_as_active(span);
             log();
+            custom();
             exception();
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,8 +135,8 @@ async fn main() {
 //!
 //! | OpenTelemetry SpanKind           | Application Insights telemetry type |
 //! | -------------------------------- | ----------------------------------- |
-//! | `CLIENT`, `PRODUCER`, `INTERNAL` | Dependency                          |
-//! | `SERVER`, `CONSUMER`             | Request                             |
+//! | `CLIENT`, `PRODUCER`, `INTERNAL` | [Dependency]                        |
+//! | `SERVER`, `CONSUMER`             | [Request]                           |
 //!
 //! The Span's status determines the Success field of a Dependency or Request. Success is `false` if
 //! the status `Error`; otherwise `true`.
@@ -148,6 +148,8 @@ async fn main() {
 //!
 //! [trace]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/trace/semantic_conventions
 //! [resource]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/resource/semantic_conventions
+//! [Dependency]: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-dependency-telemetry
+//! [Request]: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-request-telemetry
 //!
 //! | OpenTelemetry attribute key                       | Application Insights field                               |
 //! | ------------------------------------------------- | -----------------------------------------------------    |
@@ -182,7 +184,7 @@ async fn main() {
 //!
 //! ## Events
 //!
-//! Events are converted into Exception telemetry if the event name equals `"exception"` (see
+//! Events are converted into [Exception] telemetry if the event name equals `"exception"` (see
 //! OpenTelemetry semantic conventions for [exceptions]) with the following mapping:
 //!
 //! | OpenTelemetry attribute key | Application Insights field |
@@ -191,11 +193,21 @@ async fn main() {
 //! | `exception.message`         | Exception message          |
 //! | `exception.stacktrace`      | Exception call stack       |
 //!
-//! All other events are converted into Trace telemetry.
+//! Events are converted into [Event] telemetry if the event name equals `"ai.custom"` with the
+//! following mapping:
+//!
+//! | OpenTelemetry attribute key | Application Insights field |
+//! | --------------------------- | -------------------------- |
+//! | `ai.customEvent.name`       | Event name                 |
+//!
+//! All other events are converted into [Trace] telemetry.
 //!
 //! All other attributes are directly converted to custom properties.
 //!
 //! [exceptions]: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/exceptions.md
+//! [Exception]: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-exception-telemetry
+//! [Event]: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-event-telemetry
+//! [Trace]: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-trace-telemetry
 //!
 //! ## Metrics
 //!

--- a/src/models/context_tag_keys.rs
+++ b/src/models/context_tag_keys.rs
@@ -88,7 +88,8 @@ context_tag_keys! {
     /// Unique client device id. Computer name in most cases.
     DEVICE_ID("ai.device.id", 1024),
 
-    /// Device locale using <language>-<REGION> pattern, following RFC 5646. Example 'en-US'.
+    /// Device locale using &lt;language&gt;-&lt;REGION&gt; pattern, following RFC 5646. Example
+    /// 'en-US'.
     DEVICE_LOCALE("ai.device.locale", 64),
 
     /// Model of the device the end user of the application is using. Used for client scenarios. If

--- a/src/models/context_tag_keys.rs
+++ b/src/models/context_tag_keys.rs
@@ -67,6 +67,12 @@ macro_rules! context_tag_keys {
             pub const $var: opentelemetry::Key = opentelemetry::Key::from_static_str($name);)*
 
             /// Name for a custom event recorded with special name "ai.custom".
+            ///
+            /// To allow proper grouping and useful metrics, restrict your application so that it
+            /// generates a small number of separate event names. For example, don't use a separate
+            /// name for each generated instance of an event.
+            ///
+            /// If not specified, the custom event name defaults to "<no name>".
             pub const CUSTOM_EVENT_NAME: opentelemetry::Key =
                 opentelemetry::Key::from_static_str("ai.customEvent.name");
         }

--- a/src/models/context_tag_keys.rs
+++ b/src/models/context_tag_keys.rs
@@ -65,6 +65,10 @@ macro_rules! context_tag_keys {
         pub mod attrs {
             $($(#[doc = $doc])+
             pub const $var: opentelemetry::Key = opentelemetry::Key::from_static_str($name);)*
+
+            /// Name for a custom event recorded with special name "ai.custom".
+            pub const CUSTOM_EVENT_NAME: opentelemetry::Key =
+                opentelemetry::Key::from_static_str("ai.customEvent.name");
         }
 
         $($(#[doc = $doc])+

--- a/src/models/data.rs
+++ b/src/models/data.rs
@@ -1,12 +1,14 @@
 #[cfg(feature = "metrics")]
 use crate::models::MetricData;
-use crate::models::{ExceptionData, MessageData, RemoteDependencyData, RequestData};
+use crate::models::{EventData, ExceptionData, MessageData, RemoteDependencyData, RequestData};
 use serde::Serialize;
 
 /// Data struct to contain both B and C sections.
 #[derive(Debug, Serialize)]
 #[serde(tag = "baseType", content = "baseData")]
 pub(crate) enum Data {
+    #[serde(rename = "EventData")]
+    Event(EventData),
     #[serde(rename = "ExceptionData")]
     Exception(ExceptionData),
     #[serde(rename = "MessageData")]

--- a/src/models/event_data.rs
+++ b/src/models/event_data.rs
@@ -1,0 +1,18 @@
+use crate::models::{LimitedLenString512, Properties};
+use serde::Serialize;
+
+/// Instances of Event represent structured event records that can be grouped and searched by their
+/// properties. Event data item also creates a metric of event count by name.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct EventData {
+    /// Schema version
+    pub(crate) ver: i32,
+
+    /// Event name. Keep it low cardinality to allow proper grouping and useful metrics.
+    pub(crate) name: LimitedLenString512,
+
+    /// Collection of custom properties.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) properties: Option<Properties>,
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -3,6 +3,7 @@ mod data;
 #[cfg(feature = "metrics")]
 mod data_point;
 mod envelope;
+mod event_data;
 mod exception_data;
 mod exception_details;
 mod message_data;
@@ -16,6 +17,7 @@ pub(crate) use data::*;
 #[cfg(feature = "metrics")]
 pub(crate) use data_point::*;
 pub(crate) use envelope::*;
+pub(crate) use event_data::*;
 pub(crate) use exception_data::*;
 pub(crate) use exception_details::*;
 pub(crate) use message_data::*;

--- a/src/models/sanitize.rs
+++ b/src/models/sanitize.rs
@@ -43,6 +43,7 @@ limited_len_string!(LimitedLenString32768, 32768);
 limited_len_string!(LimitedLenString8192, 8192);
 limited_len_string!(LimitedLenString2048, 2048);
 limited_len_string!(LimitedLenString1024, 1024);
+limited_len_string!(LimitedLenString512, 512);
 limited_len_string!(LimitedLenString256, 256);
 limited_len_string!(LimitedLenString150, 150);
 limited_len_string!(LimitedLenString128, 128);

--- a/tests/http_requests.rs
+++ b/tests/http_requests.rs
@@ -14,7 +14,7 @@ use opentelemetry::{
     },
     Context, KeyValue,
 };
-use opentelemetry_application_insights::new_pipeline;
+use opentelemetry_application_insights::{attrs as ai, new_pipeline};
 use opentelemetry_semantic_conventions as semcov;
 use recording_client::record;
 use std::time::Duration;
@@ -76,6 +76,13 @@ fn traces_simple() {
                 let _server_guard = mark_span_as_active(span);
                 get_active_span(|span| {
                     span.add_event("An event!", vec![KeyValue::new("happened", true)]);
+                    span.add_event(
+                        "ai.custom",
+                        vec![
+                            ai::CUSTOM_EVENT_NAME.string("A custom event!"),
+                            KeyValue::new("happened", true),
+                        ],
+                    );
                     let error: Box<dyn std::error::Error> = "An error".into();
                     span.record_error(error.as_ref());
                 });

--- a/tests/snapshots/http_requests__traces_simple.snap
+++ b/tests/snapshots/http_requests__traces_simple.snap
@@ -65,6 +65,26 @@ content-encoding: gzip
   {
     "data": {
       "baseData": {
+        "name": "A custom event!",
+        "properties": {
+          "happened": "true"
+        },
+        "ver": 2
+      },
+      "baseType": "EventData"
+    },
+    "iKey": "0fdcec70-0ce5-4085-89d9-9ae8ead9af66",
+    "name": "Microsoft.ApplicationInsights.Event",
+    "sampleRate": 100.0,
+    "tags": {
+      "ai.operation.id": "STRIPPED",
+      "ai.operation.parentId": "STRIPPED"
+    },
+    "time": "STRIPPED"
+  },
+  {
+    "data": {
+      "baseData": {
         "exceptions": [
           {
             "message": "An error",


### PR DESCRIPTION
Works similar to exceptions:

- If the event name equals "ai.custom", the event is converted to Event telemetry. This appears in the customEvents table.
- The Name field is populated from the "ai.customEvent.name" attribute. Users may use the `opentelemetry_application_insights::attrs::CUSTOM_EVENT_NAME` key for convenience.

Issues/explanations:

- Why "ai.custom"? - Just "custom" seems nicer. Though I wouldn't be surprised if some users already send events with the name "custom" and I would like to avoid breaking their code. "ai.custom" seems weird enough that hopefully no one uses that, yet.
- Declaring the customEvent name as an attribute is slightly ugly. It would be much nicer if we could use the event name for that. But I'm not sure how else to identify the custom event.

Closes #53