### PR TITLE
Move OpenTelemetry 'level' to 'severityLevel' for application insights

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ opentelemetry-semantic-conventions = "0.10"
 reqwest = { version = "0.11", default-features = false, features = ["blocking"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_repr = "0.1"
 thiserror = "1"
 ureq = { version = "2", optional = true }
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,8 +1,9 @@
-use crate::models::Properties;
+use crate::models::{Properties, SeverityLevel};
 use chrono::{DateTime, SecondsFormat, Utc};
 use opentelemetry::{
     sdk::{trace::EvictedHashMap, Resource},
     trace::Status,
+    Value,
 };
 use std::time::{Duration, SystemTime};
 
@@ -44,6 +45,19 @@ pub(crate) fn status_to_result_code(status: &Status) -> i32 {
         Status::Unset => 0,
         Status::Ok => 1,
         Status::Error { .. } => 2,
+    }
+}
+
+pub(crate) fn value_to_severity_level(value: &Value) -> Option<SeverityLevel> {
+    match value.as_str().as_ref() {
+        // Convert from `tracing` Level.
+        // https://docs.rs/tracing-core/0.1.30/src/tracing_core/metadata.rs.html#526-533
+        "TRACE" => Some(SeverityLevel::Verbose),
+        "DEBUG" => Some(SeverityLevel::Information),
+        "INFO" => Some(SeverityLevel::Information),
+        "WARN" => Some(SeverityLevel::Warning),
+        "ERROR" => Some(SeverityLevel::Error),
+        _ => None,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,7 +200,11 @@ async fn main() {
 //! | --------------------------- | -------------------------- |
 //! | `ai.customEvent.name`       | Event name                 |
 //!
-//! All other events are converted into [Trace] telemetry.
+//! All other events are converted into [Trace] telemetry with the follwing mapping:
+//!
+//! | OpenTelemetry attribute key  | Application Insights field |
+//! | ---------------------------- | -------------------------- |
+//! | `level` ([`tracing::Level`]) | Severity level             |
 //!
 //! All other attributes are directly converted to custom properties.
 //!
@@ -208,6 +212,7 @@ async fn main() {
 //! [Exception]: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-exception-telemetry
 //! [Event]: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-event-telemetry
 //! [Trace]: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-trace-telemetry
+//! [`tracing::Level`]: https://docs.rs/tracing/0.1.37/tracing/struct.Level.html
 //!
 //! ## Metrics
 //!

--- a/src/models/context_tag_keys.rs
+++ b/src/models/context_tag_keys.rs
@@ -72,7 +72,7 @@ macro_rules! context_tag_keys {
             /// generates a small number of separate event names. For example, don't use a separate
             /// name for each generated instance of an event.
             ///
-            /// If not specified, the custom event name defaults to "<no name>".
+            /// If not specified, the custom event name defaults to "&lt;no name&gt;".
             pub const CUSTOM_EVENT_NAME: opentelemetry::Key =
                 opentelemetry::Key::from_static_str("ai.customEvent.name");
         }

--- a/src/models/message_data.rs
+++ b/src/models/message_data.rs
@@ -13,6 +13,7 @@ pub(crate) struct MessageData {
     /// Trace message
     pub(crate) message: LimitedLenString32768,
 
+    //Trace severity level.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) severity_level: Option<i32>,
 

--- a/src/models/message_data.rs
+++ b/src/models/message_data.rs
@@ -13,6 +13,9 @@ pub(crate) struct MessageData {
     /// Trace message
     pub(crate) message: LimitedLenString32768,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) severity_level: Option<i32>,
+
     /// Collection of custom properties.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) properties: Option<Properties>,

--- a/src/models/message_data.rs
+++ b/src/models/message_data.rs
@@ -1,4 +1,4 @@
-use crate::models::{LimitedLenString32768, Properties};
+use crate::models::{LimitedLenString32768, Properties, SeverityLevel};
 use serde::Serialize;
 
 /// Instances of Message represent printf-like trace statements that are text-searched. Log4Net,
@@ -13,9 +13,9 @@ pub(crate) struct MessageData {
     /// Trace message
     pub(crate) message: LimitedLenString32768,
 
-    //Trace severity level.
+    /// Trace severity level.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) severity_level: Option<i32>,
+    pub(crate) severity_level: Option<SeverityLevel>,
 
     /// Collection of custom properties.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -42,6 +42,7 @@ mod tests {
             tags: None,
             data: Some(Data::Message(MessageData {
                 ver: 2,
+                severity_level: None,
                 message: "hello world".into(),
                 properties: None,
             })),
@@ -88,6 +89,7 @@ mod tests {
             tags: Some(tags),
             data: Some(Data::Message(MessageData {
                 ver: 2,
+                severity_level: None,
                 message: "m".repeat(33000).into(),
                 properties: None,
             })),

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -12,6 +12,7 @@ mod metric_data;
 mod remote_dependency_data;
 mod request_data;
 mod sanitize;
+mod severity_level;
 
 pub(crate) use data::*;
 #[cfg(feature = "metrics")]
@@ -26,6 +27,7 @@ pub(crate) use metric_data::*;
 pub(crate) use remote_dependency_data::*;
 pub(crate) use request_data::*;
 pub(crate) use sanitize::*;
+pub(crate) use severity_level::*;
 
 #[cfg(test)]
 mod tests {

--- a/src/models/severity_level.rs
+++ b/src/models/severity_level.rs
@@ -1,0 +1,41 @@
+use crate::models::LimitedLenString8192;
+
+#[derive(Debug)]
+pub(crate) enum SeverityLevel {
+    Verbose,
+    Debug,
+    Information,
+    Warning,
+    Error,
+    None,
+}
+
+impl SeverityLevel {
+    pub(crate) fn to_application_insights(&self) -> Option<i32> {
+        match self {
+            SeverityLevel::Verbose => Some(0),
+            SeverityLevel::Debug => Some(1),
+            SeverityLevel::Information => Some(1),
+            SeverityLevel::Warning => Some(2),
+            SeverityLevel::Error => Some(3),
+            _ => None,
+        }
+    }
+}
+
+/// This will read from the tracing property 'level' and convert to our type.
+impl From<Option<LimitedLenString8192>> for SeverityLevel {
+    fn from(tracing_log_level: Option<LimitedLenString8192>) -> Self {
+        match tracing_log_level {
+            Some(log_level) => match log_level.as_ref() {
+                "VERBOSE" => Self::Verbose,
+                "DEBUG" => Self::Debug,
+                "INFO" => Self::Information,
+                "WARN" => Self::Warning,
+                "ERROR" => Self::Error,
+                _ => Self::None,
+            },
+            None => Self::None,
+        }
+    }
+}

--- a/src/models/severity_level.rs
+++ b/src/models/severity_level.rs
@@ -1,41 +1,11 @@
-use crate::models::LimitedLenString8192;
+use serde_repr::Serialize_repr;
 
-#[derive(Debug)]
+/// Defines the level of severity for the event.
+#[derive(Debug, Serialize_repr)]
+#[repr(u8)]
 pub(crate) enum SeverityLevel {
-    Verbose,
-    Debug,
-    Information,
-    Warning,
-    Error,
-    None,
-}
-
-impl SeverityLevel {
-    pub(crate) fn to_application_insights(&self) -> Option<i32> {
-        match self {
-            SeverityLevel::Verbose => Some(0),
-            SeverityLevel::Debug => Some(1),
-            SeverityLevel::Information => Some(1),
-            SeverityLevel::Warning => Some(2),
-            SeverityLevel::Error => Some(3),
-            _ => None,
-        }
-    }
-}
-
-/// This will read from the tracing property 'level' and convert to our type.
-impl From<Option<LimitedLenString8192>> for SeverityLevel {
-    fn from(tracing_log_level: Option<LimitedLenString8192>) -> Self {
-        match tracing_log_level {
-            Some(log_level) => match log_level.as_ref() {
-                "VERBOSE" => Self::Verbose,
-                "DEBUG" => Self::Debug,
-                "INFO" => Self::Information,
-                "WARN" => Self::Warning,
-                "ERROR" => Self::Error,
-                _ => Self::None,
-            },
-            None => Self::None,
-        }
-    }
+    Verbose = 0,
+    Information = 1,
+    Warning = 2,
+    Error = 3,
 }

--- a/tests/http_requests.rs
+++ b/tests/http_requests.rs
@@ -75,7 +75,15 @@ fn traces_simple() {
             {
                 let _server_guard = mark_span_as_active(span);
                 get_active_span(|span| {
-                    span.add_event("An event!", vec![KeyValue::new("happened", true)]);
+                    span.add_event(
+                        "An event!",
+                        vec![
+                            KeyValue::new("happened", true),
+                            // Emulate tracing level
+                            // https://docs.rs/tracing-core/0.1.30/src/tracing_core/metadata.rs.html#531
+                            KeyValue::new("level", "WARN"),
+                        ],
+                    );
                     span.add_event(
                         "ai.custom",
                         vec![

--- a/tests/snapshots/http_requests__traces_simple.snap
+++ b/tests/snapshots/http_requests__traces_simple.snap
@@ -49,6 +49,7 @@ content-encoding: gzip
         "properties": {
           "happened": "true"
         },
+        "severityLevel": 2,
         "ver": 2
       },
       "baseType": "MessageData"


### PR DESCRIPTION
Hi, thanks a lot for this crate, it has been very helpful to me. 

I've noticed that the trace logs from this crate (if using tracing crate to generate them with info!, debug!, error!) would have a custom property called error but the severity level in azure application insights would always be Verbose.

Examples:
![image](https://user-images.githubusercontent.com/11574755/222876522-86da5300-0798-4e23-861d-a3f6e50fcc7f.png)
![image](https://user-images.githubusercontent.com/11574755/222876548-660ebc4b-82fe-4491-9958-0601eeb68524.png)

I changed it to strip the "level" from the custom properties and convert it to the i32 that severity_level expects in app insights.

This is how it looks like running from this branch:
![image](https://user-images.githubusercontent.com/11574755/222876643-0d7ff5c5-4a3f-4660-b12b-8a834181978e.png)
![image](https://user-images.githubusercontent.com/11574755/222876652-7d509644-d2b5-40d8-8884-f27ade119103.png)

There are a few other logs that get generated as Verbose still but this should cater for any trace!, info!, warn! and error! logs. 

Please let me know if you want me to move code somewhere else or adjust it, I've just added a function to the same file where the message is generated.

Cheers,
Raf

