### PR TITLE
Fix tag extraction from resource attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Change how the tags Could role, Cloud role instance, Application version and Internal SDK version are extracted:
+
+  - Spans no longer extract them from span attributes. They still extract them from resource attributes. And they newly extract them also from instrumentation library attributes.
+  - Events newly extract them from resource and instrumentation library attributes.
+
+  In addition metrics no longer extract the tag Authenticated user id from the enduser.id attribute.
+
 ## [0.30.0] - 2024-03-08
 
 - Upgrade `opentelemetry` and `opentelemetry_sdk` to `v0.22`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ rand = "0.8.5"
 regex = "1.5.5"
 reqwest = { version = "0.11", default-features = false, features = ["blocking"] }
 test-case = "3.0.0"
-tokio = { version = "1.17.0", features = ["rt", "macros", "process", "time"] }
+tokio = { version = "1.17.0", features = ["rt-multi-thread", "macros", "process", "time"] }
 version-sync = { version = "0.9.4", default-features = false, features = ["html_root_url_updated", "contains_regex"] }
 
 [badges]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,21 @@ async fn main() {
 //! - [OpenTelemetry specification: Span](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#span)
 //! - [Application Insights data model](https://docs.microsoft.com/en-us/azure/azure-monitor/app/data-model)
 //!
+//! ## Resource
+//!
+//! Resource and instrumentation library attributes map to the following fields for spans, events
+//! and metrics (the mapping tries to follow the OpenTelemetry semantic conventions for [resource]).
+//!
+//! [resource]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/resource/semantic_conventions
+//!
+//! | OpenTelemetry attribute key                    | Application Insights field                               |
+//! | ---------------------------------------------- | -------------------------------------------------------- |
+//! | `service.namespace` + `service.name`           | Context: Cloud role (`ai.cloud.role`)                    |
+//! | `service.instance.id`                          | Context: Cloud role instance (`ai.cloud.roleInstance`)   |
+//! | `service.version`                              | Context: Application version (`ai.application.ver`)      |
+//! | `telemetry.sdk.name` + `telemetry.sdk.version` | Context: Internal SDK version (`ai.internal.sdkVersion`) |
+//! | `ai.*`                                         | Context: AppInsights Tag (`ai.*`)                        |
+//!
 //! ## Spans
 //!
 //! The OpenTelemetry SpanKind determines the Application Insights telemetry type:
@@ -173,22 +188,17 @@ async fn main() {
 //! the status `Error`; otherwise `true`.
 //!
 //! The following of the Span's attributes map to special fields in Application Insights (the
-//! mapping tries to follow the OpenTelemetry semantic conventions for [trace] and [resource]).
+//! mapping tries to follow the OpenTelemetry semantic conventions for [trace]).
 //!
 //! Note: for `INTERNAL` Spans the Dependency Type is always `"InProc"`.
 //!
 //! [trace]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/trace/semantic_conventions
-//! [resource]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/resource/semantic_conventions
 //! [Dependency]: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-dependency-telemetry
 //! [Request]: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-request-telemetry
 //!
 //! | OpenTelemetry attribute key                                                | Application Insights field                               |
-//! | -------------------------------------------------------------------------- | -----------------------------------------------------    |
-//! | `service.version`                                                          | Context: Application version (`ai.application.ver`)      |
+//! | -------------------------------------------------------------------------- | -------------------------------------------------------- |
 //! | `enduser.id`                                                               | Context: Authenticated user id (`ai.user.authUserId`)    |
-//! | `service.namespace` + `service.name`                                       | Context: Cloud role (`ai.cloud.role`)                    |
-//! | `service.instance.id`                                                      | Context: Cloud role instance (`ai.cloud.roleInstance`)   |
-//! | `telemetry.sdk.name` + `telemetry.sdk.version`                             | Context: Internal SDK version (`ai.internal.sdkVersion`) |
 //! | `SpanKind::Server` + `http.request.method` + `http.route`                  | Context: Operation Name (`ai.operation.name`)            |
 //! | `ai.*`                                                                     | Context: AppInsights Tag (`ai.*`)                        |
 //! | `url.full`                                                                 | Dependency Data                                          |

--- a/src/quick_pulse.rs
+++ b/src/quick_pulse.rs
@@ -1,6 +1,6 @@
 use crate::{
     models::{context_tag_keys, QuickPulseEnvelope, QuickPulseMetric},
-    tags::get_tags_from_attrs,
+    tags::get_tags_for_resource,
     trace::{get_duration, is_remote_dependency_success, is_request_success, EVENT_NAME_EXCEPTION},
     uploader_quick_pulse::{self, PostOrPing},
     Error,
@@ -170,7 +170,7 @@ impl<C: HttpClient + 'static> QuickPulseSender<C> {
         instrumentation_key: String,
         resource: Resource,
     ) -> Self {
-        let mut tags = get_tags_from_attrs(resource.iter());
+        let mut tags = get_tags_for_resource(&resource);
         let machine_name = resource
             .get(Key::from_static_str(semcov::resource::HOST_NAME))
             .map(|v| v.as_str().into_owned())

--- a/tests/snapshots/http_requests__live_metrics.snap
+++ b/tests/snapshots/http_requests__live_metrics.snap
@@ -200,6 +200,8 @@ content-encoding: gzip
     "name": "Microsoft.ApplicationInsights.Exception",
     "sampleRate": 100.0,
     "tags": {
+      "ai.cloud.role": "unknown_service",
+      "ai.internal.sdkVersion": "opentelemetry:0.22.1",
       "ai.operation.id": "STRIPPED",
       "ai.operation.parentId": "STRIPPED"
     },

--- a/tests/snapshots/http_requests__traces_simple.snap
+++ b/tests/snapshots/http_requests__traces_simple.snap
@@ -68,6 +68,7 @@ content-encoding: gzip
     "name": "Microsoft.ApplicationInsights.Message",
     "sampleRate": 100.0,
     "tags": {
+      "ai.cloud.role": "test.server",
       "ai.operation.id": "STRIPPED",
       "ai.operation.parentId": "STRIPPED"
     },
@@ -88,6 +89,7 @@ content-encoding: gzip
     "name": "Microsoft.ApplicationInsights.Event",
     "sampleRate": 100.0,
     "tags": {
+      "ai.cloud.role": "test.server",
       "ai.operation.id": "STRIPPED",
       "ai.operation.parentId": "STRIPPED"
     },
@@ -110,6 +112,7 @@ content-encoding: gzip
     "name": "Microsoft.ApplicationInsights.Exception",
     "sampleRate": 100.0,
     "tags": {
+      "ai.cloud.role": "test.server",
       "ai.operation.id": "STRIPPED",
       "ai.operation.parentId": "STRIPPED"
     },


### PR DESCRIPTION
Fixes #67

Change how the tags ai.cloud.role, ai.cloud.roleInstance, ai.application.ver and ai.internal.sdkVersion are extracted:

- Spans no longer extract them from span attributes. They still extract them from resource attributes. And they newly extract them also from instrumentation library attributes.
- Events newly extract them from resource and instrumentation library attributes.

In addition metrics no longer extract the tag ai.user.authUserId from the enduser.id attribute.