### PR TITLE
Hardcode temporality selector implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 - Set tags Cloud role and Cloud role instance also from resource attributes `k8s.{deployment,replicaset,statefulset,job,cronjob,daemonset,pod}.name`. This matches [the behavior of the JS exporter](https://github.com/Azure/azure-sdk-for-js/blob/c66cad23c4b803719db65cb48a453b0adc13307b/sdk/monitor/monitor-opentelemetry-exporter/src/utils/common.ts#L75-L138).
+- Remove option to configure temporality seletor (`with_temporality_selector`). Application Insights supports delta temporality only as defined in the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/58bfe48eabe887545198d66c43f44071b822373f/specification/metrics/sdk_exporters/otlp.md?plain=1#L46-L47).
 
 ## [0.31.0] - 2024-05-09
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,10 +330,7 @@ pub use models::context_tag_keys::attrs;
 use opentelemetry::{global, trace::TracerProvider as _, KeyValue, Value};
 pub use opentelemetry_http::HttpClient;
 #[cfg(feature = "metrics")]
-use opentelemetry_sdk::metrics::reader::{
-    AggregationSelector, DefaultAggregationSelector, DefaultTemporalitySelector,
-    TemporalitySelector,
-};
+use opentelemetry_sdk::metrics::reader::{AggregationSelector, DefaultAggregationSelector};
 use opentelemetry_sdk::{
     export::ExportError,
     runtime::RuntimeChannel,
@@ -590,8 +587,6 @@ where
             instrumentation_key: self.instrumentation_key,
             sample_rate: self.sample_rate.unwrap_or(100.0),
             #[cfg(feature = "metrics")]
-            temporality_selector: Box::new(DefaultTemporalitySelector::new()),
-            #[cfg(feature = "metrics")]
             aggregation_selector: Box::new(DefaultAggregationSelector::new()),
         }
     }
@@ -680,8 +675,6 @@ pub struct Exporter<C> {
     instrumentation_key: String,
     sample_rate: f64,
     #[cfg(feature = "metrics")]
-    temporality_selector: Box<dyn TemporalitySelector>,
-    #[cfg(feature = "metrics")]
     aggregation_selector: Box<dyn AggregationSelector>,
 }
 
@@ -710,8 +703,6 @@ impl<C> Exporter<C> {
             instrumentation_key,
             sample_rate: 100.0,
             #[cfg(feature = "metrics")]
-            temporality_selector: Box::new(DefaultTemporalitySelector::new()),
-            #[cfg(feature = "metrics")]
             aggregation_selector: Box::new(DefaultAggregationSelector::new()),
         }
     }
@@ -730,8 +721,6 @@ impl<C> Exporter<C> {
             ),
             instrumentation_key: connection_string.instrumentation_key,
             sample_rate: 100.0,
-            #[cfg(feature = "metrics")]
-            temporality_selector: Box::new(DefaultTemporalitySelector::new()),
             #[cfg(feature = "metrics")]
             aggregation_selector: Box::new(DefaultAggregationSelector::new()),
         })
@@ -757,17 +746,6 @@ impl<C> Exporter<C> {
     pub fn with_sample_rate(mut self, sample_rate: f64) -> Self {
         // Application Insights expects the sample rate as a percentage.
         self.sample_rate = sample_rate * 100.0;
-        self
-    }
-
-    /// Set temporality selector.
-    #[cfg(feature = "metrics")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
-    pub fn with_temporality_selector(
-        mut self,
-        temporality_selector: impl TemporalitySelector + 'static,
-    ) -> Self {
-        self.temporality_selector = Box::new(temporality_selector);
         self
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -27,7 +27,17 @@ where
     C: Send + Sync,
 {
     fn temporality(&self, kind: InstrumentKind) -> Temporality {
-        self.temporality_selector.temporality(kind)
+        // See https://github.com/frigus02/opentelemetry-application-insights/issues/74#issuecomment-2108488385
+        match kind {
+            InstrumentKind::Counter
+            | InstrumentKind::Histogram
+            | InstrumentKind::ObservableCounter
+            | InstrumentKind::Gauge
+            | InstrumentKind::ObservableGauge => Temporality::Delta,
+            InstrumentKind::UpDownCounter | InstrumentKind::ObservableUpDownCounter => {
+                Temporality::Cumulative
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Application Insights supports delta temporality only. Remove the option to customize the temporality selector `with_temporality_selector` and hardcode the implementation instead.

Fixes #74 