### PR TITLE
Remove sample rate from log messages

### DIFF
--- a/src/logs.rs
+++ b/src/logs.rs
@@ -50,7 +50,7 @@ impl<C> Exporter<C> {
                     .unwrap_or_else(SystemTime::now),
             )
             .into(),
-            sample_rate: Some(self.sample_rate),
+            sample_rate: None,
             i_key: Some(self.instrumentation_key.clone().into()),
             tags: Some(get_tags_for_log(&log, &self.resource)),
             data: Some(data),

--- a/tests/snapshots/http_requests__logs.snap
+++ b/tests/snapshots/http_requests__logs.snap
@@ -25,7 +25,6 @@ content-encoding: gzip
     },
     "iKey": "0fdcec70-0ce5-4085-89d9-9ae8ead9af66",
     "name": "Microsoft.ApplicationInsights.Message",
-    "sampleRate": 100.0,
     "tags": {
       "ai.cloud.role": "test.client"
     },
@@ -42,7 +41,6 @@ content-encoding: gzip
     },
     "iKey": "0fdcec70-0ce5-4085-89d9-9ae8ead9af66",
     "name": "Microsoft.ApplicationInsights.Message",
-    "sampleRate": 100.0,
     "tags": {
       "ai.cloud.role": "test.client"
     },
@@ -59,7 +57,6 @@ content-encoding: gzip
     },
     "iKey": "0fdcec70-0ce5-4085-89d9-9ae8ead9af66",
     "name": "Microsoft.ApplicationInsights.Message",
-    "sampleRate": 100.0,
     "tags": {
       "ai.cloud.role": "test.client"
     },
@@ -82,7 +79,6 @@ content-encoding: gzip
     },
     "iKey": "0fdcec70-0ce5-4085-89d9-9ae8ead9af66",
     "name": "Microsoft.ApplicationInsights.Exception",
-    "sampleRate": 100.0,
     "tags": {
       "ai.cloud.role": "test.client"
     },
@@ -99,7 +95,6 @@ content-encoding: gzip
     },
     "iKey": "0fdcec70-0ce5-4085-89d9-9ae8ead9af66",
     "name": "Microsoft.ApplicationInsights.Message",
-    "sampleRate": 100.0,
     "tags": {
       "ai.cloud.role": "test.client",
       "ai.operation.id": "STRIPPED",


### PR DESCRIPTION
I think the sampling is purely a tracing feature?