### PR TITLE
Upgrade to `opentelemetry-rust` v0.26.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,10 @@ flate2 = "1"
 http = "1"
 once_cell = "1"
 futures-util = { version = "0.3", default-features = false, optional = true }
-opentelemetry = "0.25"
-opentelemetry_sdk = "0.25"
-opentelemetry-http = "0.25"
-opentelemetry-semantic-conventions = "0.25"
+opentelemetry = "0.26"
+opentelemetry_sdk = "0.26"
+opentelemetry-http = "0.26"
+opentelemetry-semantic-conventions = "0.26"
 reqwest = { version = "0.12", default-features = false, features = ["blocking"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -62,9 +62,9 @@ doc-comment = "0.3.3"
 env_logger = "0.11.3"
 insta = "1.39.0"
 log = { version = "0.4", features = ["kv", "kv_sval"] }
-opentelemetry_sdk = { version = "0.25", features = ["rt-async-std", "rt-tokio", "rt-tokio-current-thread", "logs_level_enabled"] }
-opentelemetry-http = { version = "0.25", features = ["reqwest"] }
-opentelemetry-appender-log = { version = "0.25", features = ["with-serde"] }
+opentelemetry_sdk = { version = "0.26", features = ["rt-async-std", "rt-tokio", "rt-tokio-current-thread", "logs_level_enabled"] }
+opentelemetry-http = { version = "0.26", features = ["reqwest"] }
+opentelemetry-appender-log = { version = "0.26", features = ["with-serde"] }
 rand = "0.8.5"
 regex = "1.10.5"
 reqwest = { version = "0.12", features = ["blocking"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ futures-util = { version = "0.3", default-features = false, optional = true }
 opentelemetry = "0.26"
 opentelemetry_sdk = "0.26"
 opentelemetry-http = "0.26"
-opentelemetry-semantic-conventions = "0.26"
+opentelemetry-semantic-conventions = { version = "0.26", features = ["semconv_experimental"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/examples/opentelemetry.rs
+++ b/examples/opentelemetry.rs
@@ -2,7 +2,7 @@ use opentelemetry::{
     global,
     propagation::TextMapPropagator,
     trace::{FutureExt, Span, SpanKind, TraceContextExt, Tracer},
-    Context, Key,
+    Context, KeyValue,
 };
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use std::collections::HashMap;
@@ -16,8 +16,8 @@ async fn spawn_children(n: u32, process_name: String) {
     let tracer = global::tracer("spawn_children");
     let mut span = tracer.start("spawn_children");
     span.set_attributes([
-        Key::new("n").i64(n.into()),
-        Key::new("process_name").string(process_name.clone()),
+        KeyValue::new("n", Into::<i64>::into(n)),
+        KeyValue::new("process_name", process_name.clone()),
     ]);
     let cx = Context::current_with_span(span);
     for _ in 0..n {
@@ -33,7 +33,7 @@ async fn spawn_child_process(process_name: &str) {
         .span_builder("spawn_child_process")
         .with_kind(SpanKind::Client)
         .start(&tracer);
-    span.set_attribute(Key::new("process_name").string(process_name.to_string()));
+    span.set_attribute(KeyValue::new("process_name", process_name.to_string()));
     let cx = Context::current_with_span(span);
 
     let mut injector = HashMap::new();

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -212,7 +212,7 @@ mod tests {
 
     #[test]
     fn attrs_to_properties_filters_ms() {
-        let attrs = vec![KeyValue::new("a", "b"), KeyValue::new("_MS.a", "b")];
+        let attrs = [KeyValue::new("a", "b"), KeyValue::new("_MS.a", "b")];
         let resource = Resource::new([KeyValue::new("c", "d"), KeyValue::new("_MS.c", "d")]);
         let props = attrs_to_properties(attrs.iter(), Some(&resource), &[]).unwrap();
         assert_eq!(props.len(), 2);
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn attrs_map_to_properties_filters_ms() {
-        let attrs = vec![KeyValue::new("a", "b"), KeyValue::new("_MS.a", "b")];
+        let attrs = [KeyValue::new("a", "b"), KeyValue::new("_MS.a", "b")];
         let attrs_map = attrs_to_map(attrs.iter());
         assert_eq!(attrs_map.len(), 2);
         let props = attrs_map_to_properties(attrs_map).unwrap();
@@ -264,9 +264,9 @@ mod tests {
     #[test_case(AnyValue::Double(1.2), "1.2" ; "double")]
     #[test_case(AnyValue::String("test".into()), "test" ; "string")]
     #[test_case(AnyValue::Boolean(true), "true" ; "boolean")]
-    #[test_case(AnyValue::Bytes(Box::new(vec![])), "[]" ; "empty bytes")]
+    #[test_case(AnyValue::Bytes(Box::default()), "[]" ; "empty bytes")]
     #[test_case(AnyValue::Bytes(Box::new(vec![1, 2, 3])), "[1,2,3]" ; "bytes")]
-    #[test_case(AnyValue::ListAny(Box::new(vec![])), "[]" ; "empty list")]
+    #[test_case(AnyValue::ListAny(Box::default()), "[]" ; "empty list")]
     #[test_case(AnyValue::ListAny(Box::new(vec![1.into(), "test".into()])), "[1,test]" ; "list")]
     #[test_case(AnyValue::Map(Box::new([].into())), "{}" ; "empty map")]
     #[test_case(AnyValue::Map(Box::new([("k1".into(), "test".into())].into())), "{k1:test}" ; "map")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,8 +376,6 @@ pub use models::context_tag_keys::attrs;
 use opentelemetry::{global, trace::TracerProvider as _, KeyValue, Value};
 pub use opentelemetry_http::HttpClient;
 use opentelemetry_sdk::export::ExportError;
-#[cfg(feature = "metrics")]
-use opentelemetry_sdk::metrics::reader::{AggregationSelector, DefaultAggregationSelector};
 #[cfg(any(feature = "trace", feature = "logs"))]
 use opentelemetry_sdk::Resource;
 #[cfg(feature = "trace")]
@@ -650,7 +648,6 @@ where
             instrumentation_key: self.instrumentation_key,
             sample_rate: self.sample_rate.unwrap_or(100.0),
             #[cfg(feature = "metrics")]
-            aggregation_selector: Box::new(DefaultAggregationSelector::new()),
             resource: Resource::empty(),
         }
     }
@@ -737,8 +734,6 @@ pub struct Exporter<C> {
     instrumentation_key: String,
     #[cfg(feature = "trace")]
     sample_rate: f64,
-    #[cfg(feature = "metrics")]
-    aggregation_selector: Box<dyn AggregationSelector>,
     #[cfg(any(feature = "trace", feature = "logs"))]
     resource: Resource,
 }
@@ -769,8 +764,6 @@ impl<C> Exporter<C> {
             instrumentation_key,
             #[cfg(feature = "trace")]
             sample_rate: 100.0,
-            #[cfg(feature = "metrics")]
-            aggregation_selector: Box::new(DefaultAggregationSelector::new()),
             #[cfg(any(feature = "trace", feature = "logs"))]
             resource: Resource::empty(),
         }
@@ -791,8 +784,6 @@ impl<C> Exporter<C> {
             instrumentation_key: connection_string.instrumentation_key,
             #[cfg(feature = "trace")]
             sample_rate: 100.0,
-            #[cfg(feature = "metrics")]
-            aggregation_selector: Box::new(DefaultAggregationSelector::new()),
             #[cfg(any(feature = "trace", feature = "logs"))]
             resource: Resource::empty(),
         })
@@ -820,17 +811,6 @@ impl<C> Exporter<C> {
     pub fn with_sample_rate(mut self, sample_rate: f64) -> Self {
         // Application Insights expects the sample rate as a percentage.
         self.sample_rate = sample_rate * 100.0;
-        self
-    }
-
-    /// Set aggregation selector.
-    #[cfg(feature = "metrics")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
-    pub fn with_aggregation_selector(
-        mut self,
-        aggregation_selector: impl AggregationSelector + 'static,
-    ) -> Self {
-        self.aggregation_selector = Box::new(aggregation_selector);
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -647,7 +647,6 @@ where
             ),
             instrumentation_key: self.instrumentation_key,
             sample_rate: self.sample_rate.unwrap_or(100.0),
-            #[cfg(feature = "metrics")]
             resource: Resource::empty(),
         }
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -14,8 +14,8 @@ use opentelemetry_http::HttpClient;
 use opentelemetry_sdk::metrics::{
     data::{ExponentialHistogram, Gauge, Histogram, Metric, ResourceMetrics, Sum, Temporality},
     exporter::PushMetricsExporter,
-    reader::{AggregationSelector, TemporalitySelector},
-    Aggregation, InstrumentKind,
+    reader::TemporalitySelector,
+    InstrumentKind,
 };
 use std::{convert::TryInto, sync::Arc, time::SystemTime};
 
@@ -36,16 +36,6 @@ where
                 Temporality::Cumulative
             }
         }
-    }
-}
-
-#[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
-impl<C> AggregationSelector for Exporter<C>
-where
-    C: Send + Sync,
-{
-    fn aggregation(&self, kind: InstrumentKind) -> Aggregation {
-        self.aggregation_selector.aggregation(kind)
     }
 }
 

--- a/tests/snapshots/http_requests__live_metrics.snap
+++ b/tests/snapshots/http_requests__live_metrics.snap
@@ -21,7 +21,7 @@ x-ms-qps-role-name: unknown_service
   "RoleName": "unknown_service",
   "StreamId": "STRIPPED",
   "Timestamp": "STRIPPED",
-  "Version": "opentelemetry:0.25.0"
+  "Version": "opentelemetry:0.26.0"
 }
 
 
@@ -87,7 +87,7 @@ content-encoding: gzip
     "RoleName": "unknown_service",
     "StreamId": "STRIPPED",
     "Timestamp": "STRIPPED",
-    "Version": "opentelemetry:0.25.0"
+    "Version": "opentelemetry:0.26.0"
   }
 ]
 
@@ -144,7 +144,7 @@ content-encoding: gzip
     "RoleName": "unknown_service",
     "StreamId": "STRIPPED",
     "Timestamp": "STRIPPED",
-    "Version": "opentelemetry:0.25.0"
+    "Version": "opentelemetry:0.26.0"
   }
 ]
 
@@ -165,7 +165,7 @@ content-encoding: gzip
           "service.name": "unknown_service",
           "telemetry.sdk.language": "rust",
           "telemetry.sdk.name": "opentelemetry",
-          "telemetry.sdk.version": "0.25.0"
+          "telemetry.sdk.version": "0.26.0"
         },
         "resultCode": "2",
         "success": false,
@@ -178,7 +178,7 @@ content-encoding: gzip
     "sampleRate": 100.0,
     "tags": {
       "ai.cloud.role": "unknown_service",
-      "ai.internal.sdkVersion": "opentelemetry:0.25.0",
+      "ai.internal.sdkVersion": "opentelemetry:0.26.0",
       "ai.operation.id": "STRIPPED"
     },
     "time": "STRIPPED"
@@ -201,7 +201,7 @@ content-encoding: gzip
     "sampleRate": 100.0,
     "tags": {
       "ai.cloud.role": "unknown_service",
-      "ai.internal.sdkVersion": "opentelemetry:0.25.0",
+      "ai.internal.sdkVersion": "opentelemetry:0.26.0",
       "ai.operation.id": "STRIPPED",
       "ai.operation.parentId": "STRIPPED"
     },
@@ -217,7 +217,7 @@ content-encoding: gzip
           "service.name": "unknown_service",
           "telemetry.sdk.language": "rust",
           "telemetry.sdk.name": "opentelemetry",
-          "telemetry.sdk.version": "0.25.0"
+          "telemetry.sdk.version": "0.26.0"
         },
         "responseCode": "2",
         "success": false,
@@ -230,7 +230,7 @@ content-encoding: gzip
     "sampleRate": 100.0,
     "tags": {
       "ai.cloud.role": "unknown_service",
-      "ai.internal.sdkVersion": "opentelemetry:0.25.0",
+      "ai.internal.sdkVersion": "opentelemetry:0.26.0",
       "ai.operation.id": "STRIPPED"
     },
     "time": "STRIPPED"
@@ -245,7 +245,7 @@ content-encoding: gzip
           "service.name": "unknown_service",
           "telemetry.sdk.language": "rust",
           "telemetry.sdk.name": "opentelemetry",
-          "telemetry.sdk.version": "0.25.0"
+          "telemetry.sdk.version": "0.26.0"
         },
         "responseCode": "0",
         "success": true,
@@ -258,7 +258,7 @@ content-encoding: gzip
     "sampleRate": 100.0,
     "tags": {
       "ai.cloud.role": "unknown_service",
-      "ai.internal.sdkVersion": "opentelemetry:0.25.0",
+      "ai.internal.sdkVersion": "opentelemetry:0.26.0",
       "ai.operation.id": "STRIPPED"
     },
     "time": "STRIPPED"

--- a/tests/snapshots/http_requests__logs.snap
+++ b/tests/snapshots/http_requests__logs.snap
@@ -121,7 +121,7 @@ content-encoding: gzip
           "service.name": "unknown_service",
           "telemetry.sdk.language": "rust",
           "telemetry.sdk.name": "opentelemetry",
-          "telemetry.sdk.version": "0.25.0"
+          "telemetry.sdk.version": "0.26.0"
         },
         "resultCode": "0",
         "type": "InProc",
@@ -134,7 +134,7 @@ content-encoding: gzip
     "sampleRate": 100.0,
     "tags": {
       "ai.cloud.role": "unknown_service",
-      "ai.internal.sdkVersion": "opentelemetry:0.25.0",
+      "ai.internal.sdkVersion": "opentelemetry:0.26.0",
       "ai.operation.id": "STRIPPED"
     },
     "time": "STRIPPED"

--- a/tests/snapshots/http_requests__traces_batch_async_std.snap
+++ b/tests/snapshots/http_requests__traces_batch_async_std.snap
@@ -18,7 +18,7 @@ content-encoding: gzip
           "service.name": "unknown_service",
           "telemetry.sdk.language": "rust",
           "telemetry.sdk.name": "opentelemetry",
-          "telemetry.sdk.version": "0.25.0"
+          "telemetry.sdk.version": "0.26.0"
         },
         "resultCode": "0",
         "type": "InProc",
@@ -31,7 +31,7 @@ content-encoding: gzip
     "sampleRate": 100.0,
     "tags": {
       "ai.cloud.role": "unknown_service",
-      "ai.internal.sdkVersion": "opentelemetry:0.25.0",
+      "ai.internal.sdkVersion": "opentelemetry:0.26.0",
       "ai.operation.id": "STRIPPED"
     },
     "time": "STRIPPED"

--- a/tests/snapshots/http_requests__traces_batch_tokio.snap
+++ b/tests/snapshots/http_requests__traces_batch_tokio.snap
@@ -18,7 +18,7 @@ content-encoding: gzip
           "service.name": "unknown_service",
           "telemetry.sdk.language": "rust",
           "telemetry.sdk.name": "opentelemetry",
-          "telemetry.sdk.version": "0.25.0"
+          "telemetry.sdk.version": "0.26.0"
         },
         "resultCode": "0",
         "type": "InProc",
@@ -31,7 +31,7 @@ content-encoding: gzip
     "sampleRate": 100.0,
     "tags": {
       "ai.cloud.role": "unknown_service",
-      "ai.internal.sdkVersion": "opentelemetry:0.25.0",
+      "ai.internal.sdkVersion": "opentelemetry:0.26.0",
       "ai.operation.id": "STRIPPED"
     },
     "time": "STRIPPED"


### PR DESCRIPTION
Thank you for authoring this crate! This PR upgrades `opentelemetry-application-insights` to use `opentelemetry-rust` v0.26.0.

The relevant changes in the new version are:
- removal of `AggregationSelector`
- a new `KeyValue` API to replace `Key`

In addition, I also included a couple of clippy fixes in this PR related to `vec![]` usage.