### PR TITLE
Fix internal logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ trace = ["opentelemetry_sdk/trace"]
 metrics = ["opentelemetry_sdk/metrics"]
 logs = ["opentelemetry_sdk/logs"]
 live-metrics = ["trace", "futures-util", "sysinfo"]
+internal-logs = ["tracing"]
 # Deprecated features: These don't enable anything in
 # opentelemetry-application-insights. They only enable features in dependency
 # crates.
@@ -55,6 +56,7 @@ serde_json = "1"
 serde_repr = "0.1"
 sysinfo = { version = "0.30", optional = true }
 thiserror = "2"
+tracing = { version = ">=0.1.40", default-features = false, optional = true }
 
 [dev-dependencies]
 async-std = { version = "1.13.0", features = ["attributes"] }

--- a/src/quick_pulse.rs
+++ b/src/quick_pulse.rs
@@ -145,6 +145,7 @@ impl<R: RuntimeChannel> SpanProcessor for QuickPulseManager<R> {
 impl<R: RuntimeChannel> Drop for QuickPulseManager<R> {
     fn drop(&mut self) {
         if let Err(err) = self.shutdown() {
+            let err: &dyn std::error::Error = &err;
             opentelemetry::otel_warn!(name: "ApplicationInsights.LiveMetrics.ShutdownFailed", error = err);
         }
     }


### PR DESCRIPTION
The recent refactor to use `opentelemetry::otel_warn!()` didn't actually work correctly. This fixes it by:
- Adding a internal-logs feature
- Adding a tracing dependency

But this means we rely on the implementation details of these macros. Not sure if this is a good idea.