### PR TITLE
feat(trace): add resource attributes to events

### DIFF
--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,7 +1,7 @@
 use crate::{
     convert::{
         attrs_map_to_properties, attrs_to_map, attrs_to_properties, duration_to_string,
-        status_to_result_code, time_to_string, value_to_severity_level,
+        status_to_result_code, time_to_string, value_to_severity_level, AttrValue,
     },
     models::{
         context_tag_keys::attrs::CUSTOM_EVENT_NAME, Data, Envelope, EventData, ExceptionData,
@@ -101,15 +101,15 @@ impl<C> Exporter<C> {
         for event in span.events.iter() {
             let (data, name) = match event.name.as_ref() {
                 x if x == EVENT_NAME_CUSTOM => (
-                    Data::Event(event.into()),
+                    Data::Event(EventAndResource(event, resource).into()),
                     "Microsoft.ApplicationInsights.Event",
                 ),
                 x if x == EVENT_NAME_EXCEPTION => (
-                    Data::Exception(event.into()),
+                    Data::Exception(EventAndResource(event, resource).into()),
                     "Microsoft.ApplicationInsights.Exception",
                 ),
                 _ => (
-                    Data::Message(event.into()),
+                    Data::Message(EventAndResource(event, resource).into()),
                     "Microsoft.ApplicationInsights.Message",
                 ),
             };
@@ -440,9 +440,17 @@ impl<'a> From<SpanAndResource<'a>> for RemoteDependencyData {
     }
 }
 
-impl From<&Event> for ExceptionData {
-    fn from(event: &Event) -> ExceptionData {
+struct EventAndResource<'a>(&'a Event, &'a Resource);
+
+impl From<EventAndResource<'_>> for ExceptionData {
+    fn from(EventAndResource(event, resource): EventAndResource<'_>) -> Self {
         let mut attrs = attrs_to_map(event.attributes.iter());
+        attrs.extend(
+            resource
+                .iter()
+                .map(|(k, v)| (k.as_str(), v as &dyn AttrValue)),
+        );
+
         let exception = ExceptionDetails {
             type_name: attrs
                 .remove(semcov::trace::EXCEPTION_TYPE)
@@ -465,9 +473,14 @@ impl From<&Event> for ExceptionData {
     }
 }
 
-impl From<&Event> for EventData {
-    fn from(event: &Event) -> EventData {
+impl From<EventAndResource<'_>> for EventData {
+    fn from(EventAndResource(event, resource): EventAndResource<'_>) -> Self {
         let mut attrs = attrs_to_map(event.attributes.iter());
+        attrs.extend(
+            resource
+                .iter()
+                .map(|(k, v)| (k.as_str(), v as &dyn AttrValue)),
+        );
         EventData {
             ver: 2,
             name: attrs
@@ -484,9 +497,14 @@ impl From<&Event> for EventData {
 /// https://github.com/tokio-rs/tracing/blob/a0126b2e2d465e8e6d514acdf128fcef5b863d27/tracing-opentelemetry/src/subscriber.rs#L839
 const LEVEL: &str = "level";
 
-impl From<&Event> for MessageData {
-    fn from(event: &Event) -> MessageData {
+impl From<EventAndResource<'_>> for MessageData {
+    fn from(EventAndResource(event, resource): EventAndResource<'_>) -> Self {
         let mut attrs = attrs_to_map(event.attributes.iter());
+        attrs.extend(
+            resource
+                .iter()
+                .map(|(k, v)| (k.as_str(), v as &dyn AttrValue)),
+        );
         let severity_level = attrs.get(LEVEL).and_then(|&x| value_to_severity_level(x));
         if severity_level.is_some() {
             attrs.remove(LEVEL);

--- a/tests/snapshots/http_requests__traces.snap
+++ b/tests/snapshots/http_requests__traces.snap
@@ -92,7 +92,9 @@ content-encoding: gzip
       "baseData": {
         "message": "An event!",
         "properties": {
-          "happened": "true"
+          "happened": "true",
+          "service.name": "server",
+          "service.namespace": "test"
         },
         "severityLevel": 2,
         "ver": 2
@@ -114,7 +116,9 @@ content-encoding: gzip
       "baseData": {
         "name": "A custom event!",
         "properties": {
-          "happened": "true"
+          "happened": "true",
+          "service.name": "server",
+          "service.namespace": "test"
         },
         "ver": 2
       },
@@ -139,6 +143,10 @@ content-encoding: gzip
             "typeName": "<no type>"
           }
         ],
+        "properties": {
+          "service.name": "server",
+          "service.namespace": "test"
+        },
         "ver": 2
       },
       "baseType": "ExceptionData"


### PR DESCRIPTION
As far as I can tell from [this discussion](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18525) (and a bunch of similar ones linked from there), resource attributes should be added to `customDimensions`.