### PR TITLE
feat: implement retries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ reqwest-client-rustls = ["opentelemetry-http/reqwest", "reqwest/rustls-tls"]
 
 [dependencies]
 async-trait = "0.1"
+backon = "1.5.1"
 bytes = "1"
 chrono = "0.4"
 flate2 = "1"

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -95,6 +95,7 @@ where
                 endpoint.as_ref(),
                 envelopes,
                 self.backoff.clone(),
+                self.retry_notify.clone(),
             )
             .await
             .map_err(Into::into)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -78,6 +78,7 @@ where
                 endpoint.as_ref(),
                 envelopes,
                 self.backoff.clone(),
+                self.retry_notify.clone(),
             )
             .await
             .map_err(Into::into)

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -157,6 +157,7 @@ where
             endpoint.as_ref(),
             envelopes,
             self.backoff.clone(),
+            self.retry_notify.clone(),
         )
         .await
         .map_err(Into::into)

--- a/src/uploader_quick_pulse.rs
+++ b/src/uploader_quick_pulse.rs
@@ -107,10 +107,10 @@ pub(crate) async fn send(
             polling_interval_hint,
         })
     } else {
-        Err(Error::Upload(format!(
-            "{}: Failed to upload live metrics",
-            response.status().as_u16(),
-        )))
+        Err(Error::Upload {
+            status: response.status().as_u16(),
+            can_retry: false,
+        })
     }
 }
 


### PR DESCRIPTION
Azure Application Insights frequently times out, returns HTTP 503 errors, or only accepts partial payloads. This PR adds support for configuring a `backon`-based backoff strategy to automatically retry telemetry uploads in such cases.