### PR TITLE
Read process metrics instead of system metrics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,7 +371,7 @@ use opentelemetry_sdk::ExportError;
 #[cfg(any(feature = "trace", feature = "logs"))]
 use opentelemetry_sdk::Resource;
 #[cfg(feature = "live-metrics")]
-pub use quick_pulse::{CollectorType, LiveMetricsSpanProcessor};
+pub use quick_pulse::LiveMetricsSpanProcessor;
 use std::{
     convert::TryInto,
     error::Error as StdError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,7 +371,7 @@ use opentelemetry_sdk::ExportError;
 #[cfg(any(feature = "trace", feature = "logs"))]
 use opentelemetry_sdk::Resource;
 #[cfg(feature = "live-metrics")]
-pub use quick_pulse::LiveMetricsSpanProcessor;
+pub use quick_pulse::{CollectorType, LiveMetricsSpanProcessor};
 use std::{
     convert::TryInto,
     error::Error as StdError,

--- a/src/quick_pulse.rs
+++ b/src/quick_pulse.rs
@@ -22,7 +22,7 @@ use std::{
     },
     time::{Duration, SystemTime},
 };
-use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
+use sysinfo::{CpuRefreshKind, MemoryRefreshKind, Pid, ProcessRefreshKind, RefreshKind, System};
 
 const MAX_POST_WAIT_TIME: Duration = Duration::from_secs(20);
 const MAX_PING_WAIT_TIME: Duration = Duration::from_secs(60);
@@ -75,6 +75,15 @@ impl<R: RuntimeChannel> std::fmt::Debug for LiveMetricsSpanProcessor<R> {
     }
 }
 
+/// Metrics Collector Type
+#[derive(Debug)]
+pub enum CollectorType {
+    ///System Collector (default)
+    System,
+    ///Process Collector (collects only the app running process metrics)
+    ProcessOnly,
+}
+
 #[derive(Debug)]
 enum Message {
     Send,
@@ -87,12 +96,21 @@ impl<R: RuntimeChannel> LiveMetricsSpanProcessor<R> {
         exporter: Exporter<C>,
         runtime: R,
     ) -> LiveMetricsSpanProcessor<R> {
+        Self::new_with_collector(exporter, runtime, CollectorType::System)
+    }
+
+    /// Create new live metrics span processor with specific metrics collector.
+    pub fn new_with_collector<C: HttpClient + 'static>(
+        exporter: Exporter<C>,
+        runtime: R,
+        collector_type: CollectorType,
+    ) -> LiveMetricsSpanProcessor<R> {
         let (message_sender, message_receiver) = runtime.batch_message_channel(1);
         let delay_runtime = runtime.clone();
         let is_collecting_outer = Arc::new(AtomicBool::new(false));
         let is_collecting = is_collecting_outer.clone();
         let shared_outer = Arc::new(Mutex::new(Shared {
-            metrics_collector: MetricsCollector::new(),
+            metrics_collector: MetricsCollector::new(collector_type),
             resource_data: (&exporter.resource).into(),
         }));
         let shared = shared_outer.clone();
@@ -315,9 +333,84 @@ impl<C: HttpClient + 'static> Sender<C> {
     }
 }
 
+enum HardwareCollector {
+    System {
+        system: System,
+        refresh_kind: RefreshKind,
+    },
+    Process {
+        pid: Pid,
+        system: System,
+        refresh_kind: ProcessRefreshKind,
+    },
+}
+
+impl HardwareCollector {
+    fn refresh_specifics(&mut self) {
+        match self {
+            HardwareCollector::System {
+                system,
+                refresh_kind,
+            } => system.refresh_specifics(*refresh_kind),
+            HardwareCollector::Process {
+                pid,
+                system,
+                refresh_kind,
+            } => {
+                system.refresh_processes_specifics(
+                    sysinfo::ProcessesToUpdate::Some(&[*pid]),
+                    true,
+                    *refresh_kind,
+                );
+            }
+        }
+    }
+
+    fn collect_cpu_usage(&mut self, metrics: &mut Vec<QuickPulseMetric>) {
+        let mut cpu_usage = 0.;
+
+        match self {
+            HardwareCollector::System { system, .. } => {
+                for cpu in system.cpus() {
+                    cpu_usage += f64::from(cpu.cpu_usage());
+                }
+            }
+            HardwareCollector::Process { pid, system, .. } => {
+                if let Some(process) = system.process(*pid) {
+                    cpu_usage += f64::from(process.cpu_usage())
+                }
+            }
+        }
+
+        metrics.push(QuickPulseMetric {
+            name: METRIC_PROCESSOR_TIME,
+            value: cpu_usage,
+            weight: 1,
+        });
+    }
+
+    fn collect_memory_usage(&mut self, metrics: &mut Vec<QuickPulseMetric>) {
+        let memory_usage = match self {
+            HardwareCollector::System { system, .. } => system.used_memory(),
+            HardwareCollector::Process { pid, system, .. } => {
+                if let Some(process) = system.process(*pid) {
+                    process.memory()
+                } else {
+                    0
+                }
+            }
+        };
+
+        metrics.push(QuickPulseMetric {
+            name: METRIC_COMMITTED_BYTES,
+            value: memory_usage as f64,
+            weight: 1,
+        });
+    }
+}
+
 struct MetricsCollector {
-    system: System,
-    system_refresh_kind: RefreshKind,
+    hardware_collector: HardwareCollector,
     request_count: usize,
     request_failed_count: usize,
     request_duration: Duration,
@@ -329,12 +422,23 @@ struct MetricsCollector {
 }
 
 impl MetricsCollector {
-    fn new() -> Self {
+    fn new(collector_type: CollectorType) -> Self {
+        let cpu_mem_collector = match collector_type {
+            CollectorType::System => HardwareCollector::System {
+                system: System::new(),
+                refresh_kind: RefreshKind::nothing()
+                    .with_cpu(CpuRefreshKind::nothing().with_cpu_usage())
+                    .with_memory(MemoryRefreshKind::nothing().with_ram()),
+            },
+            CollectorType::ProcessOnly => HardwareCollector::Process {
+                system: System::new(),
+                pid: Pid::from_u32(std::process::id()),
+                refresh_kind: ProcessRefreshKind::nothing().with_cpu().with_memory(),
+            },
+        };
+
         Self {
-            system: System::new(),
-            system_refresh_kind: RefreshKind::nothing()
-                .with_cpu(CpuRefreshKind::nothing().with_cpu_usage())
-                .with_memory(MemoryRefreshKind::nothing().with_ram()),
+            hardware_collector: cpu_mem_collector,
             request_count: 0,
             request_failed_count: 0,
             request_duration: Duration::default(),
@@ -385,32 +489,12 @@ impl MetricsCollector {
 
     fn collect_and_reset(&mut self) -> Vec<QuickPulseMetric> {
         let mut metrics = Vec::new();
-        self.system.refresh_specifics(self.system_refresh_kind);
-        self.collect_cpu_usage(&mut metrics);
-        self.collect_memory_usage(&mut metrics);
+        self.hardware_collector.refresh_specifics();
+        self.hardware_collector.collect_cpu_usage(&mut metrics);
+        self.hardware_collector.collect_memory_usage(&mut metrics);
         self.collect_requests_dependencies_exceptions(&mut metrics);
         self.reset();
         metrics
-    }
-
-    fn collect_cpu_usage(&mut self, metrics: &mut Vec<QuickPulseMetric>) {
-        let mut cpu_usage = 0.;
-        for cpu in self.system.cpus() {
-            cpu_usage += f64::from(cpu.cpu_usage());
-        }
-        metrics.push(QuickPulseMetric {
-            name: METRIC_PROCESSOR_TIME,
-            value: cpu_usage,
-            weight: 1,
-        });
-    }
-
-    fn collect_memory_usage(&mut self, metrics: &mut Vec<QuickPulseMetric>) {
-        metrics.push(QuickPulseMetric {
-            name: METRIC_COMMITTED_BYTES,
-            value: self.system.used_memory() as f64,
-            weight: 1,
-        });
     }
 
     fn collect_requests_dependencies_exceptions(&mut self, metrics: &mut Vec<QuickPulseMetric>) {


### PR DESCRIPTION
I have an app service plan where I run my app (and sometimes run multiple apps) and it usually has a bit of bloat due to kudu and a bunch of of other things that I usually can monitor in the appservice plan metrics.

I wanted the LiveMetrics in here to be related to the app and only the app, so I made a change to allow us to choose if we want the system metrics (default new behaviour as it's what's happening already) or if we want only the app process to be used for the metric collections.

Here's my test app using the existing system metrics (only behaviour available on main currently):
`.with_span_processor(opentelemetry_application_insights::LiveMetricsSpanProcessor::new(exporter, opentelemetry_sdk::runtime::Tokio))`

<img width="2037" height="747" alt="image" src="https://github.com/user-attachments/assets/5937ff92-51a2-476e-aa83-6c9da56d6357" />

This is if I enable the Process only option:
`.with_span_processor(opentelemetry_application_insights::LiveMetricsSpanProcessor::new_with_collector(exporter, opentelemetry_sdk::runtime::Tokio, CollectorType::ProcessOnly))`

<img width="2035" height="799" alt="image" src="https://github.com/user-attachments/assets/7b4c3d47-cda4-4476-989f-7d590d1af194" />


