### PR TITLE
Remove reqwest dependency and features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- **Breaking:** Removed dependency on `reqwest` and the Cargo features `reqwest-*`. These have been aliases for features in `opentelemetry-http` and `reqwest` for a while now. Use the features `reqwest`, `reqwest-blocking`, `reqwest-rustls`, `reqwest-rustls-webpki-roots` in `opentelemetry-http` instead.
+
 ## [0.44.0] - 2025-10-05
 
 - Upgrade `opentelemetry` dependencies to `v0.31`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,14 +38,6 @@ metrics = ["opentelemetry_sdk/metrics"]
 logs = ["opentelemetry_sdk/logs"]
 live-metrics = ["trace", "futures-util", "sysinfo", "opentelemetry_sdk/experimental_trace_batch_span_processor_with_async_runtime"]
 internal-logs = ["tracing"]
-# Deprecated features: These don't enable anything in
-# opentelemetry-application-insights. They only enable features in dependency
-# crates.
-reqwest-blocking-client = ["reqwest-client"]
-reqwest-blocking-client-rustls = ["reqwest-client-rustls"]
-reqwest-client = ["opentelemetry-http/reqwest", "reqwest/native-tls"]
-reqwest-client-vendored-tls = ["opentelemetry-http/reqwest", "reqwest/native-tls-vendored"]
-reqwest-client-rustls = ["opentelemetry-http/reqwest", "reqwest/rustls-tls"]
 
 [dependencies]
 async-trait = "0.1"
@@ -60,7 +52,6 @@ opentelemetry = "0.31"
 opentelemetry-http = "0.31"
 opentelemetry-semantic-conventions = { version = "0.31", features = ["semconv_experimental"] }
 opentelemetry_sdk = "0.31"
-reqwest = { version = "0.12", default-features = false, features = ["blocking"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,7 +392,7 @@ pub struct Exporter<C> {
     #[cfg(feature = "live-metrics")]
     live_ping_endpoint: http::Uri,
     instrumentation_key: String,
-    retry_notify: Option<Arc<Mutex<dyn FnMut(&Error, Duration) + Send + 'static>>>,
+    retry_notify: Option<Arc<Mutex<uploader::RetryNotifyFn>>>,
     #[cfg(feature = "trace")]
     sample_rate: f64,
     #[cfg(any(feature = "trace", feature = "logs"))]

--- a/src/quick_pulse.rs
+++ b/src/quick_pulse.rs
@@ -118,9 +118,11 @@ impl<R: RuntimeChannel> LiveMetricsSpanProcessor<R> {
                         let (resource_data, metrics) = {
                             let mut shared = shared.lock().unwrap();
                             let resource_data = shared.resource_data.clone();
-                            let metrics = curr_is_collecting
-                                .then(|| shared.metrics_collector.collect_and_reset())
-                                .unwrap_or_default();
+                            let metrics = if curr_is_collecting {
+                                shared.metrics_collector.collect_and_reset()
+                            } else {
+                                Default::default()
+                            };
                             (resource_data, metrics)
                         };
                         let (next_is_collecting, next_timeout) = sender

--- a/src/quick_pulse.rs
+++ b/src/quick_pulse.rs
@@ -181,8 +181,8 @@ impl<R: RuntimeChannel> SpanProcessor for LiveMetricsSpanProcessor<R> {
 impl<R: RuntimeChannel> Drop for LiveMetricsSpanProcessor<R> {
     fn drop(&mut self) {
         if let Err(err) = self.shutdown() {
-            let err: &dyn std::error::Error = &err;
-            opentelemetry::otel_warn!(name: "ApplicationInsights.LiveMetrics.ShutdownFailed", error = err);
+            let err = err.to_string();
+            opentelemetry::otel_warn!(name: "ApplicationInsights.LiveMetrics.ShutdownFailed", error = &err);
         }
     }
 }

--- a/src/uploader.rs
+++ b/src/uploader.rs
@@ -47,12 +47,14 @@ struct ErrorDetails {
     status_code: u16,
 }
 
+pub(crate) type RetryNotifyFn = dyn FnMut(&Error, Duration) + Send + 'static;
+
 /// Sends a telemetry items to the server.
 pub(crate) async fn send(
     client: &dyn HttpClient,
     endpoint: &Uri,
     items: Vec<Envelope>,
-    retry_notify: Option<Arc<Mutex<dyn FnMut(&Error, Duration) + Send + 'static>>>,
+    retry_notify: Option<Arc<Mutex<RetryNotifyFn>>>,
 ) -> Result<(), Error> {
     let attempt = |mut items: Vec<Envelope>| async {
         match send_internal(client, endpoint, &items).await {
@@ -112,7 +114,7 @@ async fn send_internal(
     endpoint: &Uri,
     items: &[Envelope],
 ) -> Result<(), UploadError> {
-    let payload = Bytes::from(serialize_envelopes(items).map_err(|err| UploadError::Fatal(err))?);
+    let payload = Bytes::from(serialize_envelopes(items).map_err(UploadError::Fatal)?);
 
     let request = Request::post(endpoint)
         .header(http::header::CONTENT_TYPE, "application/json")
@@ -141,7 +143,7 @@ pub(crate) fn serialize_request_body(data: &[u8]) -> Result<Vec<u8>, Error> {
     // serde_json::to_writer(gzip_encoder):          247ms
     let mut gzip_encoder = GzEncoder::new(Vec::new(), Compression::default());
     gzip_encoder
-        .write_all(&data)
+        .write_all(data)
         .map_err(Error::UploadCompressRequest)?;
     gzip_encoder.finish().map_err(Error::UploadCompressRequest)
 }


### PR DESCRIPTION
This crate doesn't need the dependency and the features are just aliases for features in the opentelemetry-http crate.

Removing the features means less maintenance work here for reqwest updates and users will only need to wait for opentelemetry-http to support newer reqwuest versions and not this crate in addition.

Fixes #113 
Fixes #51